### PR TITLE
Codec registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following functions can be found in the `com.github.agcom.bson.serialization
 
 #### Serializers
 
-Various **bson types adapter serializers** can be found under `com.github.agcom.bson.serialization.serializers` package. Be sure to check them before implementing yours.
+Various **bson types adapter serializers** can be found under `com.github.agcom.bson.serialization.serializers` package. Be sure to check them before implementing yours. Also, you can always use `@ContextualSerializer` for them.
 
 > E.g. `BsonValueSerializer`, `TemporalSerializer` and `RegexSerializer`.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following functions can be found in the `com.github.agcom.bson.serialization
 
 #### Serializers
 
-Various **bson types adapter serializers** can be found under `com.github.agcom.bson.serialization.serializers` package. Be sure to check them before implementing yours. Also, you can always use `@ContextualSerializer` for them.
+Various **bson types adapter serializers** can be found under `com.github.agcom.bson.serialization.serializers` package. Be sure to check them before implementing yours. Also, you can always use `@ContextualSerializer` for the bson types.
 
 > E.g. `BsonValueSerializer`, `TemporalSerializer` and `RegexSerializer`.
 
@@ -125,54 +125,47 @@ Provides extensions to use the serialization library with [MongoDB Java driver](
 	}
 	```
 
-- Serialization codec registry (*1)
+- Serialization codec registry
 
-	An adapter between a serialization `Bson` instance and `CodecRegistry`.
+  An adapter between a serialization `Bson` instance and `CodecRegistry`.
 
-	```kotlin
-	import kotlinx.serialization.*
-	import com.github.agcom.bson.serialization.*
-	import com.github.agcom.bson.mongodb.codecs.*
-	import org.bson.codecs.configuration.CodecRegistry
-	
-	@Serializable
-	data class Project(val name: String, val language: String)
-	
-	val bson = Bson(BsonConfiguration.DEFAULT)
-	
-	fun main() {
-	    val registry: CodecRegistry = SerializationCodecRegistry(bson) // Look here
-	    ...
-	}
-	```
+  ```kotlin
+  import kotlinx.serialization.*
+  import com.github.agcom.bson.serialization.*
+  import com.github.agcom.bson.mongodb.codecs.*
+  import org.bson.codecs.configuration.CodecRegistry
+  
+  @Serializable
+  data class Project(val name: String, val language: String)
+  
+  val bson = Bson(BsonConfiguration.DEFAULT)
+  
+  fun main() {
+      val registry: CodecRegistry = SerializationCodecRegistry(bson) // Look here
+      ...
+  }
+  ```
 
-	The registry infers the serializer instance for a requested class in the following order,
-
-	1. Class annotated with `@Serializable`
-	2. Build-in types. E.g. `String`, `Long`, ...
-	3. Contextual (`context` parameter provided at `Bson` instance creation)
-	4. Polymorphic serializer (never fails, #26)
-
-	> 1. May behave inconsistently (#26). So, it's recommended to be composed after a more trusted registry.
-	>
-	> 	```kotlin
-	> 	import kotlinx.serialization.*
-	> 	import com.github.agcom.bson.serialization.*
-	> 	import com.github.agcom.bson.mongodb.codecs.*
-	> 	import com.mongodb.MongoClientSettings
-	> 	import org.bson.codecs.configuration.CodecRegistries
-	> 	
-	> 	@Serializable
-	> 	data class Project(val name: String, val language: String)
-	> 	
-	> 	val bson = Bson(BsonConfiguration.DEFAULT)
-	> 	
-	> 	fun main() {
-	> 	    val registry = CodecRegistries.fromRegistries(
-	> 	        MongoClientSettings.getDefaultCodecRegistry(), // The default driver codec registry
-	> 	        SerializationCodecRegistry(bson)
-	> 	    )
-	> 	    ...
-	> 	}
-	> 	```
+  > It's recommended to compose the registry after the default registry. This reduces hip-hops (better performance) when working with simple bson types.
+  >
+  > ```kotlin
+  > import kotlinx.serialization.*
+  > import com.github.agcom.bson.serialization.*
+  > import com.github.agcom.bson.mongodb.codecs.*
+  > import com.mongodb.MongoClientSettings
+  > import org.bson.codecs.configuration.CodecRegistries
+  > 
+  > @Serializable
+  > data class Project(val name: String, val language: String)
+  > 
+  > val bson = Bson(BsonConfiguration.DEFAULT)
+  > 
+  > fun main() {
+  >     val registry = CodecRegistries.fromRegistries(
+  >         MongoClientSettings.getDefaultCodecRegistry(), // The driver's default codec registry
+  >         SerializationCodecRegistry(bson)
+  >     )
+  >     ...
+  > }
+  > ```
 

--- a/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/codecs/SerializationCodecRegistry.kt
+++ b/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/codecs/SerializationCodecRegistry.kt
@@ -1,13 +1,14 @@
 package com.github.agcom.bson.mongodb.codecs
 
+import com.github.agcom.bson.mongodb.utils.getPolymorphic
 import com.github.agcom.bson.serialization.Bson
 import kotlinx.serialization.ImplicitReflectionSerializer
-import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.serializerOrNull
 import org.bson.codecs.Codec
+import org.bson.codecs.configuration.CodecConfigurationException
 import org.bson.codecs.configuration.CodecRegistry
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
-import kotlinx.serialization.serializerOrNull
 
 /**
  * Adapter between serialization [Bson] and [CodecRegistry].
@@ -15,25 +16,34 @@ import kotlinx.serialization.serializerOrNull
  * 1. Class annotated with `@Serializable`
  * 2. Built-in type. E.g. `String`, `Long`, ...
  * 3. Contextual
- * 4. Polymorphic serializer (never fails, #26)
+ * 4. Polymorphic
  */
 class SerializationCodecRegistry(private val bson: Bson) : CodecRegistry {
 
-    private val cache: ConcurrentMap<Class<*>, Codec<*>> = ConcurrentHashMap()
+    private val cache: ConcurrentMap<Class<*>, SerializationCodec<*>> = ConcurrentHashMap()
 
     @OptIn(ImplicitReflectionSerializer::class)
-    override fun <T : Any> get(clazz: Class<T>): Codec<T> {
+    override fun <T : Any> get(clazz: Class<T>): SerializationCodec<T> {
         @Suppress("UNCHECKED_CAST")
         return cache.getOrPut(clazz, {
             val kClazz = clazz.kotlin
             SerializationCodec(
-                bson,
-                kClazz.serializerOrNull() ?: bson.context.getContextual(kClazz) ?: PolymorphicSerializer(kClazz),
-                kClazz
+                bson = bson,
+                serializer = kClazz.serializerOrNull()
+                    ?: bson.context.getContextual(kClazz)
+                    ?: bson.context.getPolymorphic(kClazz)
+                    ?: throw CodecConfigurationException("No serializer found for the requested class '${clazz.name}', hence no codec can be provided"),
+                clazz = kClazz
             )
-        }) as Codec<T>
+        }) as SerializationCodec<T>
     }
 
-    override fun <T : Any> get(clazz: Class<T>, registry: CodecRegistry): Codec<T> = get(clazz)
+    override fun <T : Any> get(clazz: Class<T>, registry: CodecRegistry?): SerializationCodec<T>? {
+        return try {
+            get(clazz)
+        } catch (ex: CodecConfigurationException) {
+            null
+        }
+    }
 
 }

--- a/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializer.kt
+++ b/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializer.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.KClass
  * The serializer yielded from the second condition is unsafe, because there is no guarantee that all sub-classes of [kClass] are present.
  * @return A [PolymorphicSerializer] for the [kClass] or null if no polymorphic serializer related to the [kClass] is registered.
  */
-fun <T : Any> SerialModule.getPolymorphic(kClass: KClass<T>): PolymorphicSerializer<T>? {
+internal fun <T : Any> SerialModule.getPolymorphic(kClass: KClass<T>): PolymorphicSerializer<T>? {
     lateinit var baseClazz: KClass<T> // The T type is not correct (should be 'in T' = '? super T'), yet I'm forced to do this because of the PolymorphicSerializer's type parameter
     try {
         dumpTo(object : SerialModuleCollector {

--- a/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializer.kt
+++ b/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializer.kt
@@ -1,0 +1,40 @@
+package com.github.agcom.bson.mongodb.utils
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.modules.SerialModule
+import kotlinx.serialization.modules.SerialModuleCollector
+import kotlin.reflect.KClass
+
+/**
+ * Iterates on all of the registered polymorphic serializers.
+ * Won't fail (returns a non-null [PolymorphicSerializer]) if one of the below conditions hold,
+ * - A serializer for the [kClass] is registered as a subclass (safe serializer)
+ * - [kClass] is registered as a base class (unsafe serializer)
+ * The serializer yielded from the second condition is unsafe, because there is no guarantee that all sub-classes of [kClass] are present.
+ * @return A [PolymorphicSerializer] for the [kClass] or null if no polymorphic serializer related to the [kClass] is registered.
+ */
+fun <T : Any> SerialModule.getPolymorphic(kClass: KClass<T>): KSerializer<T>? {
+    try {
+        dumpTo(object : SerialModuleCollector {
+            override fun <T : Any> contextual(kClass: KClass<T>, serializer: KSerializer<T>) {
+                // No op
+            }
+
+            @Suppress("UNCHECKED_CAST", "PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+            override fun <Base : Any, Sub : Base> polymorphic(
+                baseClass: KClass<Base>,
+                subClass: KClass<Sub>,
+                subSerializer: KSerializer<Sub>
+            ) {
+                if (kClass == subClass || kClass == baseClass) throw SerializerFoundException
+            }
+
+        })
+    } catch (ex: SerializerFoundException) {
+        return PolymorphicSerializer(kClass)
+    }
+    return null
+}
+
+private object SerializerFoundException : RuntimeException("Stop dumping, already found the needed serializer")

--- a/mongodb/src/test/kotlin/com/github/agcom/bson/mongodb/codecs/SerializationCodecRegistryTest.kt
+++ b/mongodb/src/test/kotlin/com/github/agcom/bson/mongodb/codecs/SerializationCodecRegistryTest.kt
@@ -1,41 +1,124 @@
 package com.github.agcom.bson.mongodb.codecs
 
+import com.github.agcom.bson.mongodb.models.*
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.booleans.shouldBeTrue
-import io.kotest.matchers.nulls.shouldNotBeNull
 import kotlinx.serialization.modules.SerializersModule
-import com.github.agcom.bson.mongodb.models.Data
-import com.github.agcom.bson.mongodb.models.IntMessage
-import com.github.agcom.bson.mongodb.models.Message
-import com.github.agcom.bson.mongodb.models.StringMessage
 import com.github.agcom.bson.serialization.*
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.modules.contextual
+import org.bson.*
+import org.bson.codecs.DecoderContext
+import org.bson.codecs.EncoderContext
+import org.bson.codecs.configuration.CodecConfigurationException
+import org.bson.types.ObjectId
 
 class SerializationCodecRegistryTest : FreeSpec({
 
-    val bson = Bson(BsonConfiguration.DEFAULT)
+    val bson = Bson(BsonConfiguration.DEFAULT, SerializersModule {
+        contextual(NoSerializableAnnotationData.Companion)
+        polymorphic<Message> {
+            subclass(IntMessage.serializer())
+            subclass(StringMessage.serializer())
+        }
+    })
+    val registry = SerializationCodecRegistry(bson)
 
-    "default" {
-        val registry = SerializationCodecRegistry(bson)
-        val codec = registry[Data::class.java]
-        codec.shouldNotBeNull()
-        (codec is SerializationCodec).shouldBeTrue()
+    "class annotated with @Serializable" {
+        registry[Filter::class.java].encoderClass shouldBe Filter::class.java
     }
 
-    "polymorphic" {
-        val registry = SerializationCodecRegistry(
-            Bson(
-                BsonConfiguration.DEFAULT,
-                SerializersModule {
-                    polymorphic<Message> {
-                        subclass(IntMessage.serializer())
-                        subclass(StringMessage.serializer())
-                    }
-                }
-            )
-        )
-        val codec = registry[Message::class.java]
-        codec.shouldNotBeNull()
-        (codec is SerializationCodec).shouldBeTrue()
+    "built-in type" {
+        registry[String::class.java].encoderClass shouldBe String::class.java
+    }
+
+    "contextual" {
+        registry[NoSerializableAnnotationData::class.java].encoderClass shouldBe NoSerializableAnnotationData::class.java
+    }
+
+    "polymorphic" - {
+
+        "base class" {
+            registry[Message::class.java].encoderClass shouldBe Message::class.java
+        }
+
+        "sub class" {
+            registry[IntMessage::class.java].encoderClass shouldBe IntMessage::class.java
+        }
+
+    }
+
+    "fail; No serializer" {
+        shouldThrow<CodecConfigurationException> {
+            registry[Field::class.java]
+        }
+    }
+
+    "bson types" - {
+
+        "BsonValue" {
+            registry[BsonValue::class.java].encoderClass shouldBe BsonValue::class.java
+        }
+
+        "BsonDocument" {
+            registry[BsonDocument::class.java].encoderClass shouldBe BsonDocument::class.java
+        }
+
+        "BsonArray" {
+            registry[BsonArray::class.java].encoderClass shouldBe BsonArray::class.java
+        }
+
+        "BsonObjectId" {
+            registry[BsonObjectId::class.java].encoderClass shouldBe BsonObjectId::class.java
+        }
+
+        "ObjectId" {
+            registry[ObjectId::class.java].encoderClass shouldBe ObjectId::class.java
+        }
+
+    }
+
+    // encode/decode tests; Counts as black-box in this context.
+    "black box tests" - {
+
+        "BsonDocument" - {
+            val codec = registry[BsonDocument::class.java]
+
+            "encode" {
+                val expected = BsonDocument("hello", BsonString("world"))
+                val doc = BsonDocument()
+                codec.encode(BsonDocumentWriter(doc), expected, EncoderContext.builder().build())
+                doc shouldBe expected
+            }
+
+            "decode" {
+                val expected = BsonDocument("hello", BsonString("world"))
+                val doc = codec.decode(BsonDocumentReader(expected).apply { readBsonType() }, DecoderContext.builder().build())
+                doc shouldBe expected
+            }
+
+        }
+
+        "a model" - {
+            val codec = registry[Message::class.java]
+
+            "encode" {
+                val msg = StringMessage("hello")
+                val expected = BsonDocument("value", BsonString(msg.value)).append(bson.configuration.classDiscriminator, BsonString(StringMessage.serializer().descriptor.serialName))
+                val written = BsonDocument()
+                codec.encode(BsonDocumentWriter(written), msg, EncoderContext.builder().build())
+                written shouldBe expected
+            }
+
+            "decode" {
+                val expected = StringMessage("hello")
+                val doc = BsonDocument("value", BsonString(expected.value)).append(bson.configuration.classDiscriminator, BsonString(StringMessage.serializer().descriptor.serialName))
+                val msg = codec.decode(BsonDocumentReader(doc).apply { readBsonType() }, DecoderContext.builder().build())
+                msg shouldBe expected
+            }
+
+        }
+
     }
 
 })

--- a/mongodb/src/test/kotlin/com/github/agcom/bson/mongodb/models/Samples.kt
+++ b/mongodb/src/test/kotlin/com/github/agcom/bson/mongodb/models/Samples.kt
@@ -9,10 +9,8 @@ import kotlinx.serialization.Serializer
 data class Data(val value: String?)
 
 data class NoSerializableAnnotationData(val value: String?) {
-
     @Serializer(NoSerializableAnnotationData::class)
     companion object : KSerializer<NoSerializableAnnotationData>
-
 }
 
 enum class Field {
@@ -38,8 +36,7 @@ data class IntMessage(val value: Int) : Message
 
 @Serializable
 @SerialName("string")
-data class StringMessage(val value: String) :
-    Message
+data class StringMessage(val value: String) : Message
 
 object EmptyMessage : Message {
 

--- a/mongodb/src/test/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializerTest.kt
+++ b/mongodb/src/test/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializerTest.kt
@@ -1,0 +1,34 @@
+package com.github.agcom.bson.mongodb.utils
+
+import com.github.agcom.bson.mongodb.models.*
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.kotest.matchers.types.shouldBeTypeOf
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.modules.SerializersModule
+
+class PolymorphicSerializerTest : FreeSpec({
+
+    val module = SerializersModule {
+        polymorphic<Message> {
+            subclass(IntMessage.serializer())
+            subclass(StringMessage.serializer())
+        }
+    }
+
+    "registered as a subclass; Safe" {
+        module.getPolymorphic(IntMessage::class).shouldNotBeNull()
+    }
+
+    "registered as a base class; Unsafe" {
+        module.getPolymorphic(Message::class).shouldNotBeNull()
+    }
+
+    "not registered; Fails" {
+        module.getPolymorphic(Filter::class).shouldBeNull()
+    }
+
+})

--- a/mongodb/src/test/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializerTest.kt
+++ b/mongodb/src/test/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializerTest.kt
@@ -20,11 +20,17 @@ class PolymorphicSerializerTest : FreeSpec({
     }
 
     "registered as a subclass; Safe" {
-        module.getPolymorphic(IntMessage::class).shouldNotBeNull()
+        module.getPolymorphic(IntMessage::class).let {
+            it.shouldNotBeNull()
+            it.baseClass shouldBe Message::class
+        }
     }
 
     "registered as a base class; Unsafe" {
-        module.getPolymorphic(Message::class).shouldNotBeNull()
+        module.getPolymorphic(Message::class).let {
+            it.shouldNotBeNull()
+            it.baseClass shouldBe Message::class
+        }
     }
 
     "not registered; Fails" {

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -84,13 +84,33 @@ class Bson(
 
 }
 
-private val defaultBsonModule: SerialModule = serializersModuleOf(
+private val bsonTypesModule: SerialModule = serializersModuleOf(
     mapOf(
         BsonValue::class to BsonValueSerializer,
+        BsonDocument::class to BsonDocumentSerializer,
+        BsonArray::class to BsonArraySerializer,
+        BsonBinary::class to BsonPrimitiveSerializer,
+        BsonBoolean::class to BsonPrimitiveSerializer,
+        BsonDateTime::class to BsonPrimitiveSerializer,
+        BsonDecimal128::class to BsonPrimitiveSerializer,
+        BsonDouble::class to BsonPrimitiveSerializer,
+        BsonInt32::class to BsonPrimitiveSerializer,
+        BsonInt64::class to BsonPrimitiveSerializer,
+        BsonJavaScript::class to BsonPrimitiveSerializer,
+        BsonNull::class to BsonPrimitiveSerializer,
+        BsonNumber::class to BsonPrimitiveSerializer,
+        BsonObjectId::class to BsonPrimitiveSerializer,
+        BsonRegularExpression::class to BsonPrimitiveSerializer,
+        BsonString::class to BsonPrimitiveSerializer,
         Binary::class to BinarySerializer,
         ObjectId::class to ObjectIdSerializer,
-        Decimal128::class to Decimal128Serializer,
-        Regex::class to RegexSerializer,
-        Pattern::class to PatternSerializer
+        Decimal128::class to Decimal128Serializer
     )
 )
+
+private val defaultBsonModule: SerialModule = SerializersModule {
+    include(bsonTypesModule)
+    include(bsonTemporalModule)
+    contextual(RegexSerializer)
+    contextual(PatternSerializer)
+}

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/TemporalSerializer.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/TemporalSerializer.kt
@@ -1,6 +1,8 @@
 package com.github.agcom.bson.serialization.serializers
 
 import kotlinx.serialization.*
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import java.time.*
 import java.time.temporal.Temporal
 
@@ -110,4 +112,15 @@ object ZonedDateTimeSerializer : TemporalSerializer<ZonedDateTime>(ZonedDateTime
     override fun ofEpochMillis(temporal: Long): ZonedDateTime =
         ZonedDateTime.ofInstant(InstantSerializer.ofEpochMillis(temporal), ZoneOffset.UTC)
 
+}
+
+internal val bsonTemporalModule = SerializersModule {
+    contextual(InstantSerializer)
+    contextual(LocalDateTimeSerializer)
+    contextual(LocalDateSerializer)
+    contextual(LocalTimeSerializer)
+    contextual(OffsetDateTimeSerializer)
+    contextual(OffsetTimeSerializer)
+    contextual(ZonedDateTimeSerializer)
+    contextual(TemporalSerializer)
 }


### PR DESCRIPTION
- Fixed #26 using the described hack (`dumpTo`).

- Extended the `Bson` default context module

- Fixed and extended `SerializationCodecRegistryTest`

- Updated README accordingly