### PR TITLE
Load

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Provides extensions to use the serialization library with [MongoDB Java driver](
   import kotlinx.serialization.*
   import com.github.agcom.bson.serialization.*
   import com.github.agcom.bson.mongodb.codecs.*
-  import org.bson.codecs.configuration.CodecRegistry
+  import org.bson.codecs.configuration.*
+  import com.mongodb.MongoClientSettings
   
   @Serializable
   data class Project(val name: String, val language: String)
@@ -141,31 +142,15 @@ Provides extensions to use the serialization library with [MongoDB Java driver](
   val bson = Bson(BsonConfiguration.DEFAULT)
   
   fun main() {
-      val registry: CodecRegistry = SerializationCodecRegistry(bson) // Look here
+      // Composing two registries
+  	val registry: CodecRegistry = CodecRegistries.fromRegistries(
+          MongoClientSettings.getDefaultCodecRegistry(), // The driver's default codec registry
+		SerializationCodecRegistry(bson) // Serialization registry
+  	)
       ...
   }
   ```
-
-  > It's recommended to compose the registry after the default registry. This reduces hip-hops (better performance) when working with simple bson types.
+  
+  > It's **recommended** to compose the serialization registry after the **default registry**. This reduces hip-hops (better performance) when working with simple bson types.
   >
-  > ```kotlin
-  > import kotlinx.serialization.*
-  > import com.github.agcom.bson.serialization.*
-  > import com.github.agcom.bson.mongodb.codecs.*
-  > import com.mongodb.MongoClientSettings
-  > import org.bson.codecs.configuration.CodecRegistries
-  > 
-  > @Serializable
-  > data class Project(val name: String, val language: String)
-  > 
-  > val bson = Bson(BsonConfiguration.DEFAULT)
-  > 
-  > fun main() {
-  >     val registry = CodecRegistries.fromRegistries(
-  >         MongoClientSettings.getDefaultCodecRegistry(), // The driver's default codec registry
-  >         SerializationCodecRegistry(bson)
-  >     )
-  >     ...
-  > }
-  > ```
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Currently, only supports **Kotlin 1.3.72** and **Kotlinx serialization runtime 0
 
 Here is a small example,
 
-> The following example illustrates working with `BsonValue` instances.
->
-> Read *[Serialization functions](#serialization-functions)* section below for byte arrays conversations (`dump`, `load`).
-
 ```kotlin
 import kotlinx.serialization.*
 import com.github.agcom.bson.serialization.*
@@ -49,7 +45,7 @@ fun main() {
     val data = Project("com.github.agcom.bson", "Kotlin")
     
     // Serializing
-    val bsonValue = bson.toBson(Project.serializer(), data) // A `BsonValue` child, in this case `BsonDocument`
+    val bsonValue = bson.toBson(Project.serializer(), data) // A `BsonValue` child, in this case a `BsonDocument`
     println(bsonValue) // {"name": "com.github.agcom.bson", "language": "Kotlin"}
     
     // Deserializing
@@ -69,34 +65,36 @@ The following functions can be found in the `com.github.agcom.bson.serialization
 
 - `dump` and `load`,
 
-	```kotlin
-	import kotlinx.serialization.*
-	import com.github.agcom.bson.serialization.*
-	import org.bson.*
-	
-	@Serializable
-	data class Project(val name: String, val language: String)
-	
-	val bson = Bson(BsonConfiguration.DEFAULT)
-	
-	fun main() {
-	    val data = Project("com.github.agcom.bson", "Kotlin")
-	
-	    // Dump
-	    val bytes = bson.dump(Project.serializer(), data)
-	
-	    // Load (*1)
-	    println(
-	        bson.load(Project.serializer(), bytes)
-	    ) // Project(name=com.github.agcom, language=Kotlin)
-	}
-	```
+  ```kotlin
+  import kotlinx.serialization.*
+  import com.github.agcom.bson.serialization.*
+  import org.bson.*
+  
+  @Serializable
+  data class Project(val name: String, val language: String)
+  
+  val bson = Bson(BsonConfiguration.DEFAULT)
+  
+  fun main() {
+      val data = Project("com.github.agcom.bson", "Kotlin")
+  
+      // Dump
+      val bytes = bson.dump(Project.serializer(), data)
+  
+      // Load
+      println(
+          bson.load(Project.serializer(), bytes)
+      ) // Project(name=com.github.agcom, language=Kotlin)
+  }
+  ```
 
-	> 1. Limited functionality (#18). You can use the other function signature `load(serializer, bytes, bsonType)` to semi-bypass this issue.
+  > Doesn't support loading/dumping **primitive types**.
 
 #### Serializers
 
-Various **bson types adapter serializers** can be found under `com.github.agcom.bson.serialization.serializers` package. Be sure to check them before implementing yours. Also, you can always use `@ContextualSerializer` for the bson types.
+Various **bson types adapter serializers** can be found under `com.github.agcom.bson.serialization.serializers` package.
+
+Those are all registered as default contextual serializers, so you can use `@ContextualSerializer` safely.
 
 > E.g. `BsonValueSerializer`, `TemporalSerializer` and `RegexSerializer`.
 
@@ -145,7 +143,7 @@ Provides extensions to use the serialization library with [MongoDB Java driver](
       // Composing two registries
   	val registry: CodecRegistry = CodecRegistries.fromRegistries(
           MongoClientSettings.getDefaultCodecRegistry(), // The driver's default codec registry
-		SerializationCodecRegistry(bson) // Serialization registry
+			SerializationCodecRegistry(bson) // Serialization registry
   	)
       ...
   }

--- a/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/codecs/BsonValueTransformingCodec.kt
+++ b/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/codecs/BsonValueTransformingCodec.kt
@@ -8,10 +8,13 @@ import org.bson.codecs.Codec
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 
+/**
+ * For internal use.
+ */
 abstract class BsonValueTransformingCodec<T> : Codec<T> {
 
     companion object {
-        val bsonCodec: Codec<BsonValue> = BsonValueCodec()
+        private val bsonCodec: Codec<BsonValue> = BsonValueCodec()
     }
 
     final override fun encode(writer: BsonWriter, value: T, encoderContext: EncoderContext) {

--- a/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializer.kt
+++ b/mongodb/src/main/kotlin/com/github/agcom/bson/mongodb/utils/PolymorphicSerializer.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
  * @return A [PolymorphicSerializer] for the [kClass] or null if no polymorphic serializer related to the [kClass] is registered.
  */
 internal fun <T : Any> SerialModule.getPolymorphic(kClass: KClass<T>): PolymorphicSerializer<T>? {
-    lateinit var baseClazz: KClass<T> // The T type is not correct (should be 'in T' = '? super T'), yet I'm forced to do this because of the PolymorphicSerializer's type parameter
+    lateinit var baseClazz: KClass<T>
     try {
         dumpTo(object : SerialModuleCollector {
             override fun <T : Any> contextual(kClass: KClass<T>, serializer: KSerializer<T>) {

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
@@ -4,9 +4,7 @@ import com.github.agcom.bson.serialization.decoders.BsonInput
 import com.github.agcom.bson.serialization.encoders.BsonOutput
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
-import org.bson.types.Binary
-import org.bson.types.Decimal128
-import org.bson.types.ObjectId
+import org.bson.types.*
 import java.util.regex.Pattern
 
 /**

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/streaming/Input.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/streaming/Input.kt
@@ -1,12 +1,8 @@
 package com.github.agcom.bson.serialization.streaming
 
-import com.github.agcom.bson.serialization.utils.RawBsonValue
+import com.github.agcom.bson.serialization.utils.toBsonArray
 import org.bson.*
-import org.bson.BsonType.*
 import org.bson.io.BsonInput
-import org.bson.types.Decimal128
-
-internal fun BsonInput.readBson(): BsonValue = RawBsonValue.eager(this)
 
 internal fun BsonInput.readBsonDocument(): BsonDocument {
     val doc = BsonDocument()
@@ -20,79 +16,5 @@ internal fun BsonInput.readBsonDocument(): BsonDocument {
 }
 
 internal fun BsonInput.readBsonArray(): BsonArray {
-    val doc = readBsonDocument()
-    val arr = BsonArray()
-    var counter = 0
-    doc.forEach { (key, value) ->
-        val index = key.toIntOrNull() ?: throw BsonSerializationException("Not a bson array")
-        if (index != counter++) throw BsonSerializationException("Not a bson array")
-        arr.add(value)
-    }
-    return arr
-}
-
-internal fun BsonInput.readBsonJavaScript(): BsonJavaScript {
-    return BsonJavaScript(readString())
-}
-
-internal fun BsonInput.readBsonInt64(): BsonInt64 {
-    return BsonInt64(readInt64())
-}
-
-internal fun BsonInput.readBsonDateTime(): BsonDateTime {
-    return BsonDateTime(readInt64())
-}
-
-internal fun BsonInput.readBsonBoolean(): BsonBoolean {
-    return BsonBoolean(
-        when (readByte()) {
-            1.toByte() -> true
-            0.toByte() -> false
-            else -> throw BsonSerializationException("Not a '$BOOLEAN'")
-        }
-    )
-}
-
-internal fun BsonInput.readBsonBinary(): BsonBinary {
-    var size = readInt32()
-    if (size < 0) throw BsonSerializationException("Invalid binary data size '$size'")
-    val binaryType = readByte()
-    if (binaryType == BsonBinarySubType.OLD_BINARY.value) {
-        val repeatedSize: Int = readInt32()
-        if (repeatedSize != size - 4) throw BsonSerializationException("Binary sub type OldBinary has inconsistent sizes")
-        size -= 4
-    }
-    val bytes = ByteArray(size)
-    readBytes(bytes)
-    return BsonBinary(binaryType, bytes)
-}
-
-internal fun BsonInput.readBsonInt32(): BsonInt32 {
-    return BsonInt32(readInt32())
-}
-
-internal fun BsonInput.readBsonString(): BsonString {
-    return BsonString(readString())
-}
-
-internal fun BsonInput.readBsonDouble(): BsonDouble {
-    return BsonDouble(readDouble())
-}
-
-internal fun BsonInput.readBsonObjectId(): BsonObjectId {
-    return BsonObjectId(readObjectId())
-}
-
-internal fun BsonInput.readBsonRegularExpression(): BsonRegularExpression {
-    return BsonRegularExpression(readCString(), readCString())
-}
-
-internal fun BsonInput.readBsonDecimal128(): BsonDecimal128 {
-    val low = readInt64()
-    val high = readInt64()
-    return BsonDecimal128(Decimal128.fromIEEE754BIDEncoding(high, low))
-}
-
-internal fun BsonInput.readBsonNull(): BsonNull {
-    return BsonNull.VALUE
+    return readBsonDocument().toBsonArray() ?: throw BsonSerializationException("Not a bson array")
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/streaming/Output.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/streaming/Output.kt
@@ -1,84 +1,20 @@
 package com.github.agcom.bson.serialization.streaming
 
-import com.github.agcom.bson.serialization.BsonEncodingException
-import com.github.agcom.bson.serialization.utils.*
-import org.bson.*
+import com.github.agcom.bson.serialization.utils.toBsonDocument
+import org.bson.BsonArray
+import org.bson.BsonBinaryWriter
+import org.bson.BsonDocument
 import org.bson.io.BsonOutput
 
-internal fun BsonOutput.writeBson(bson: BsonValue) {
-    bson.fold(
-        primitive = { writePrimitive(it) },
-        document = { writeDocument(it) },
-        array = { writeArray(it) },
-        unexpected = { throw BsonEncodingException("Unexpected bson type '${it.bsonType}'") }
-    )
-}
-
-private fun BsonOutput.writePrimitive(bson: BsonValue) {
-    bson.fold(
-        primitive = {
-            when {
-                it.isDouble -> writeDouble(it.asDouble().value)
-                it.isString -> writeString(it.asString().value)
-                it.isBinary -> {
-                    it.asBinary(); it as BsonBinary
-                    var totalLen: Int = it.data.size
-                    if (it.type == BsonBinarySubType.OLD_BINARY.value) totalLen += 4
-                    writeInt32(totalLen)
-                    writeByte(it.type.toInt())
-                    if (it.type == BsonBinarySubType.OLD_BINARY.value) writeInt32(totalLen - 4)
-                    writeBytes(it.data)
-                }
-                it.isObjectId -> writeObjectId(it.asObjectId().value)
-                it.isBoolean -> writeByte(if (it.asBoolean().value) 1 else 0)
-                it.isDateTime -> writeInt64(it.asDateTime().value)
-                it.isNull -> { /* No op */ }
-                it.isRegularExpression -> {
-                    it.asRegularExpression(); it as BsonRegularExpression
-                    writeCString(it.pattern)
-                    writeCString(it.options)
-                }
-                it.isJavaScript -> writeString(it.asJavaScript().code)
-                it.isInt32 -> writeInt32(it.asInt32().value)
-                it.isInt64 -> writeInt64(it.asInt64().value)
-                it.isDecimal128 -> {
-                    it.asDecimal128(); it as BsonDecimal128
-                    writeInt64(it.value.low)
-                    writeInt64(it.value.high)
-                }
-                else -> throw BsonEncodingException("Unexpected bson type '${it.bsonType}'")
-            }
-        },
-        unexpected = { throw BsonEncodingException("Unexpected bson type '${it.bsonType}'") }
-    )
-}
-
-private fun BsonOutput.writeDocument(doc: BsonDocument) {
+internal fun BsonOutput.writeBsonDocument(doc: BsonDocument) {
     val writer = BsonBinaryWriter(this)
-    BsonDocumentReader(doc).use { reader ->
+    doc.asBsonReader().use { reader ->
         writer.use {
             it.pipe(reader)
         }
     }
 }
 
-private fun BsonOutput.writeArray(array: BsonArray) {
-    val doc = BsonDocument()
-    array.forEachIndexed { i, value ->
-        doc[i.toString()] = value
-    }
-    writeDocument(doc)
-    /*// Old procedure
-    val startPosition = position
-    writeInt32(0) // reserve space for size
-    array.forEachIndexed { i, it ->
-    writeByte(it.bsonType.value)
-    writeCString(i.toString())
-    writeBson(it)
-    }
-    writeByte(END_OF_DOCUMENT.value)
-
-    val size = position - startPosition
-    writeInt32(startPosition, size)
-    */
+internal fun BsonOutput.writeBsonArray(array: BsonArray) {
+    writeBsonDocument(array.toBsonDocument())
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -1,9 +1,10 @@
 package com.github.agcom.bson.serialization.utils
 
-import org.bson.*
+import org.bson.BsonArray
+import org.bson.BsonDocument
 import org.bson.BsonType.*
+import org.bson.BsonValue
 
-// There is still a small chance of mis-predicting, e.g. when a `RawBsonValue` is a document and a primitive.
 // unexpected will be called in case of unknown type or a deprecated/internal bson type.
 internal inline fun <R> BsonValue.fold(
     primitive: (BsonValue) -> R = { unexpected(it) },
@@ -12,10 +13,38 @@ internal inline fun <R> BsonValue.fold(
     noinline unexpected: (BsonValue) -> R
 ): R {
     return when (bsonType) {
-        ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although maybe a primitive.
+        ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although the user might meant a document.
         DOCUMENT -> document(asDocument())
         DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL ->
             primitive(this)
         else -> unexpected(this)
     }
+}
+
+/**
+ * Transform a [BsonDocument] into a [BsonArray].
+ * The document keys should be consecutive numbers starting from 0;
+ * @return null if the document is not representing an array.
+ */
+fun BsonDocument.toBsonArray(): BsonArray? {
+    val arr = BsonArray()
+    var counter = 0
+    forEach { (key, value) ->
+        val index = key.toIntOrNull() ?: return null
+        if (index != counter++) return null
+        arr.add(value)
+    }
+    return arr
+}
+
+/**
+ * Transform a [BsonArray] into a [BsonDocument].
+ * The returned document keys will be array indexes.
+ */
+fun BsonArray.toBsonDocument(): BsonDocument {
+    val doc = BsonDocument()
+    forEachIndexed { i, value ->
+        doc[i.toString()] = value
+    }
+    return doc
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -1,0 +1,21 @@
+package com.github.agcom.bson.serialization.utils
+
+import org.bson.*
+import org.bson.BsonType.*
+
+// There is still a small chance of mis-predicting, e.g. when a `RawBsonValue` is a document and a primitive.
+// unexpected will be called in case of unknown type or a deprecated/internal bson type.
+internal inline fun <R> BsonValue.fold(
+    primitive: (BsonValue) -> R = { unexpected(it) },
+    document: (BsonDocument) -> R = { unexpected(it) },
+    array: (BsonArray) -> R = { unexpected(it) },
+    noinline unexpected: (BsonValue) -> R
+): R {
+    return when (bsonType) {
+        ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although maybe a primitive.
+        DOCUMENT -> document(asDocument())
+        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL ->
+            primitive(this)
+        else -> unexpected(this)
+    }
+}

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/decoders/BsonPrimitiveTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/decoders/BsonPrimitiveTest.kt
@@ -1,17 +1,17 @@
 package com.github.agcom.bson.serialization.decoders
 
+import com.github.agcom.bson.serialization.Bson
+import com.github.agcom.bson.serialization.BsonConfiguration
 import com.github.agcom.bson.serialization.models.HttpError
-import com.github.agcom.bson.serialization.serializers.NullSerializer
-import com.github.agcom.bson.serialization.*
 import com.github.agcom.bson.serialization.serializers.*
-import com.github.agcom.bson.serialization.utils.asEmbedded
 import com.github.agcom.bson.serialization.utils.toBsonBinary
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.builtins.serializer
 import org.bson.*
-import org.bson.types.*
-import java.nio.ByteBuffer
+import org.bson.types.Binary
+import org.bson.types.Decimal128
+import org.bson.types.ObjectId
 import java.time.Clock
 import java.util.*
 import kotlin.random.Random
@@ -131,154 +131,6 @@ class BsonPrimitiveTest : FreeSpec({
 
             bson.fromBson(HttpError.serializer(), BsonString(notFound.name)) shouldBe notFound
             bson.fromBson(HttpError.serializer(), BsonString(error.name)) shouldBe error
-        }
-
-    }
-
-    "load (custom function)" - {
-
-        fun bytes(value: Int): ByteArray = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(value).array().reversedArray()
-        fun bytes(value: String): ByteArray = byteArrayOf(
-            *ByteBuffer.allocate(4).putInt(value.length + 1).array().reversedArray(),
-            *value.toByteArray(),
-            0
-        )
-
-        fun bytes(value: Long): ByteArray = ByteBuffer.allocate(Long.SIZE_BYTES).putLong(value).array().reversedArray()
-        fun bytes(value: Double): ByteArray = ByteBuffer.allocate(8).putDouble(value).array().reversedArray()
-
-        "double" {
-            val d = Random.nextDouble()
-            bson.load(Double.serializer(), bytes(d), type = BsonType.DOUBLE) shouldBe d
-        }
-
-        "string" {
-            val str = UUID.randomUUID().toString()
-            bson.load(String.serializer(), bytes(str), type = BsonType.STRING) shouldBe str
-        }
-
-        "binary" {
-            val binary = Binary(Random.nextBytes(100))
-            bson.load(
-                BinarySerializer, byteArrayOf(
-                    *bytes(binary.data.size),
-                    binary.type,
-                    *binary.data
-                ), type = BsonType.BINARY
-            ) shouldBe binary
-        }
-
-        "object id" {
-            val id = ObjectId()
-            bson.load(ObjectIdSerializer, id.toByteArray(), type = BsonType.OBJECT_ID) shouldBe id
-        }
-
-        "boolean" {
-            val bool = Random.nextBoolean()
-            bson.load(
-                Boolean.serializer(), byteArrayOf(
-                    if (bool) 1 else 0
-                ), type = BsonType.BOOLEAN
-            ) shouldBe bool
-        }
-
-        "date time" {
-            val t = Clock.systemUTC().millis()
-            bson.load(DateTimeSerializer, bytes(t), type = BsonType.DATE_TIME) shouldBe t
-        }
-
-        "null" {
-            bson.load(NullSerializer, byteArrayOf(), type = BsonType.NULL) shouldBe null
-        }
-
-        "java script" {
-            val code = "main() {}"
-            bson.load(JavaScriptSerializer, bytes(code), type = BsonType.JAVASCRIPT) shouldBe code
-        }
-
-        "int 32" {
-            val i = Random.nextInt()
-            bson.load(Int.serializer(), bytes(i), type = BsonType.INT32) shouldBe i
-        }
-
-        "int 64" {
-            val l = Random.nextLong()
-            bson.load(Long.serializer(), bytes(l), type = BsonType.INT64) shouldBe l
-        }
-
-        "decimal 128" {
-            val decimal = Decimal128(Random.nextLong())
-            bson.load(
-                Decimal128Serializer, byteArrayOf(
-                    *bytes(decimal.low),
-                    *bytes(decimal.high)
-                ), type = BsonType.DECIMAL128
-            ) shouldBe decimal
-        }
-
-        "regular expresion" - {
-
-            "without options" {
-                val regex = Regex("acme.*corp")
-                bson.load(
-                    RegexSerializer, byteArrayOf(
-                        *bytes(regex.pattern).let { it.sliceArray(4 until it.size) }, // CString, size omitted
-                        0 // Options; Nothing
-                    ), type = BsonType.REGULAR_EXPRESSION
-                ) shouldBe regex
-            }
-
-            "with options" {
-                val regex =
-                    Regex(
-                        "acme.*corp", setOf(
-                            RegexOption.IGNORE_CASE,
-                            RegexOption.MULTILINE,
-                            RegexOption.UNIX_LINES,
-                            RegexOption.COMMENTS,
-                            RegexOption.DOT_MATCHES_ALL
-                        )
-                    )
-                bson.load(RegexSerializer, byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) },
-                    *bytes(
-                        regex.options.asEmbedded().toSortedSet().joinToString("")
-                    ).let { it.sliceArray(4 until it.size) }
-                ), type = BsonType.REGULAR_EXPRESSION) shouldBe regex
-            }
-
-            "a hard one" {
-                val regex = Regex(
-                    "[+-]?(\\d+(\\.\\d+)?|\\.\\d+)([eE][+-]?\\d+)?", setOf(
-                        RegexOption.IGNORE_CASE,
-                        RegexOption.MULTILINE,
-                        RegexOption.UNIX_LINES,
-                        RegexOption.COMMENTS,
-                        RegexOption.DOT_MATCHES_ALL
-                    )
-                )
-                bson.load(
-                    RegexSerializer, byteArrayOf(
-                        *bytes(regex.pattern).let { it.sliceArray(4 until it.size) },
-                        *bytes(
-                            regex.options.asEmbedded().toSortedSet().joinToString("")
-                        ).let { it.sliceArray(4 until it.size) }
-                    ), type = BsonType.REGULAR_EXPRESSION
-                ) shouldBe regex
-            }
-        }
-
-        "enum kind" - {
-
-            "test 1" {
-                val notFound = HttpError.NOT_FOUND
-                bson.load(HttpError.serializer(), bytes(notFound.name), type = BsonType.STRING) shouldBe notFound
-            }
-
-            "test 2" {
-                val error = HttpError.INTERNAL_SERVER_ERROR
-                bson.load(HttpError.serializer(), bytes(error.name), type = BsonType.STRING) shouldBe error
-            }
         }
 
     }

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/decoders/BsonValuePrimitiveTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/decoders/BsonValuePrimitiveTest.kt
@@ -1,13 +1,13 @@
 package com.github.agcom.bson.serialization.decoders
 
-import com.github.agcom.bson.serialization.*
+import com.github.agcom.bson.serialization.Bson
+import com.github.agcom.bson.serialization.BsonConfiguration
 import com.github.agcom.bson.serialization.serializers.BsonValueSerializer
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import org.bson.*
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
-import java.nio.ByteBuffer
 import java.time.Clock
 import kotlin.random.Random
 
@@ -87,119 +87,6 @@ class BsonValuePrimitiveTest : FreeSpec({
         "bson string" {
             val str = BsonString("hello")
             bson.fromBson(BsonValueSerializer, str) shouldBe str
-        }
-
-    }
-
-    "load (custom function)" - {
-
-        fun bytes(value: Int): ByteArray = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(value).array().reversedArray()
-        fun bytes(value: String): ByteArray = byteArrayOf(
-            *ByteBuffer.allocate(4).putInt(value.length + 1).array().reversedArray(),
-            *value.toByteArray(),
-            0
-        )
-
-        fun bytes(value: Long): ByteArray = ByteBuffer.allocate(Long.SIZE_BYTES).putLong(value).array().reversedArray()
-        fun bytes(value: Double): ByteArray = ByteBuffer.allocate(8).putDouble(value).array().reversedArray()
-
-        "bson binary" {
-            val binary = BsonBinary(Random.nextBytes(100))
-            bson.load(
-                BsonValueSerializer, byteArrayOf(
-                    *bytes(binary.data.size),
-                    binary.type,
-                    *binary.data
-                ), type = BsonType.BINARY
-            ) shouldBe binary
-        }
-
-        "bson boolean" {
-            val bool = BsonBoolean(Random.nextBoolean())
-            bson.load(
-                BsonValueSerializer, byteArrayOf(
-                    if (bool.value) 1 else 0
-                ), type = BsonType.BOOLEAN
-            ) shouldBe bool
-        }
-
-        "bson date-time" {
-            val t = BsonDateTime(Clock.systemUTC().millis())
-            bson.load(BsonValueSerializer, bytes(t.value), type = BsonType.DATE_TIME) shouldBe t
-        }
-
-        "bson decimal-128" {
-            val decimal = BsonDecimal128(Decimal128(Random.nextLong()))
-            bson.load(
-                BsonValueSerializer, byteArrayOf(
-                    *bytes(decimal.value.low),
-                    *bytes(decimal.value.high)
-                ), type = BsonType.DECIMAL128
-            ) shouldBe decimal
-        }
-
-        "bson double" {
-            val d = BsonDouble(Random.nextDouble())
-            bson.load(BsonValueSerializer, bytes(d.value), type = BsonType.DOUBLE) shouldBe d
-        }
-
-        "bson int-32" {
-            val i = BsonInt32(Random.nextInt())
-            bson.load(BsonValueSerializer, bytes(i.value), type = BsonType.INT32) shouldBe i
-        }
-
-        "bson int-64" {
-            val l = BsonInt64(Random.nextLong())
-            bson.load(BsonValueSerializer, bytes(l.value), type = BsonType.INT64) shouldBe l
-        }
-
-        "bson java-script" {
-            val js = BsonJavaScript("main() {}")
-            bson.load(BsonValueSerializer, bytes(js.code), type = BsonType.JAVASCRIPT) shouldBe js
-        }
-
-        "bson null" {
-            bson.load(BsonValueSerializer, byteArrayOf(), type = BsonType.NULL) shouldBe BsonNull.VALUE
-        }
-
-        "bson object-id" {
-            val id = BsonObjectId(ObjectId())
-            bson.load(BsonValueSerializer, id.value.toByteArray(), type = BsonType.OBJECT_ID) shouldBe id
-        }
-
-        "bson regular expression" - {
-
-            "without options" {
-                val regex = BsonRegularExpression("acme.*corp")
-                bson.load(
-                    BsonValueSerializer, byteArrayOf(
-                        *bytes(regex.pattern).let { it.sliceArray(4 until it.size) }, // CString, size omitted
-                        0 // Options; Nothing
-                    ), type = BsonType.REGULAR_EXPRESSION
-                ) shouldBe regex
-            }
-
-            "with options" {
-                val regex = BsonRegularExpression("acme.*corp", "imdxs")
-                bson.load(BsonValueSerializer, byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) },
-                    *bytes(regex.options).let { it.sliceArray(4 until it.size) }
-                ), type = BsonType.REGULAR_EXPRESSION) shouldBe regex
-            }
-
-            "a hard one" {
-                val regex = BsonRegularExpression("[+-]?(\\d+(\\.\\d+)?|\\.\\d+)([eE][+-]?\\d+)?", "imdxs")
-                bson.load(BsonValueSerializer, byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) },
-                    *bytes(regex.options).let { it.sliceArray(4 until it.size) }
-                ), type = BsonType.REGULAR_EXPRESSION) shouldBe regex
-            }
-
-        }
-
-        "bson string" {
-            val str = BsonString("hello")
-            bson.load(BsonValueSerializer, bytes(str.value), type = BsonType.STRING) shouldBe str
         }
 
     }

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/encoders/BsonPrimitiveTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/encoders/BsonPrimitiveTest.kt
@@ -1,11 +1,9 @@
 package com.github.agcom.bson.serialization.encoders
 
-import com.github.agcom.bson.serialization.models.HttpError
-import com.github.agcom.bson.serialization.serializers.NullSerializer
 import com.github.agcom.bson.serialization.Bson
 import com.github.agcom.bson.serialization.BsonConfiguration
+import com.github.agcom.bson.serialization.models.HttpError
 import com.github.agcom.bson.serialization.serializers.*
-import com.github.agcom.bson.serialization.utils.asEmbedded
 import com.github.agcom.bson.serialization.utils.toBsonBinary
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -14,7 +12,6 @@ import org.bson.*
 import org.bson.types.Binary
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
-import java.nio.ByteBuffer
 import java.time.Clock
 import java.util.*
 import kotlin.random.Random
@@ -123,139 +120,6 @@ class BsonPrimitiveTest : FreeSpec({
 
             bson.toBson(HttpError.serializer(), notFound) shouldBe BsonString(notFound.name)
             bson.toBson(HttpError.serializer(), error) shouldBe BsonString(error.name)
-        }
-
-    }
-
-    "dump" - {
-
-        fun bytes(value: Int): ByteArray = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(value).array().reversedArray()
-        fun bytes(value: String): ByteArray = byteArrayOf(
-            *ByteBuffer.allocate(4).putInt(value.length + 1).array().reversedArray(),
-            *value.toByteArray(),
-            0
-        )
-
-        fun bytes(value: Long): ByteArray = ByteBuffer.allocate(Long.SIZE_BYTES).putLong(value).array().reversedArray()
-        fun bytes(value: Double): ByteArray = ByteBuffer.allocate(8).putDouble(value).array().reversedArray()
-
-        "double" {
-            val d = Random.nextDouble()
-            bson.dump(Double.serializer(), d) shouldBe bytes(d)
-        }
-
-        "string" {
-            val str = UUID.randomUUID().toString()
-            bson.dump(String.serializer(), str) shouldBe bytes(str)
-        }
-
-        "binary" {
-            val binary = Binary(Random.nextBytes(100))
-            bson.dump(BinarySerializer, binary) shouldBe byteArrayOf(
-                *bytes(binary.data.size),
-                binary.type,
-                *binary.data
-            )
-        }
-
-        "object id" {
-            val id = ObjectId()
-            bson.dump(ObjectIdSerializer, id) shouldBe id.toByteArray()
-        }
-
-        "boolean" {
-            val bool = Random.nextBoolean()
-            bson.dump(Boolean.serializer(), bool) shouldBe byteArrayOf(
-                if (bool) 1 else 0
-            )
-        }
-
-        "date time" {
-            val t = Clock.systemUTC().millis()
-            bson.dump(DateTimeSerializer, t) shouldBe bytes(t)
-        }
-
-        "null" {
-            bson.dump(NullSerializer, null) shouldBe byteArrayOf()
-        }
-
-        "java script" {
-            val code = "main() {}"
-            bson.dump(JavaScriptSerializer, code) shouldBe bytes(code)
-        }
-
-        "int 32" {
-            val i = Random.nextInt()
-            bson.dump(Int.serializer(), i) shouldBe bytes(i)
-        }
-
-        "int 64" {
-            val l = Random.nextLong()
-            bson.dump(Long.serializer(), l) shouldBe bytes(l)
-        }
-
-        "decimal 128" {
-            val decimal = Decimal128(Random.nextLong())
-            bson.dump(Decimal128Serializer, decimal) shouldBe byteArrayOf(
-                *bytes(decimal.low),
-                *bytes(decimal.high)
-            )
-        }
-
-        "regular expresion" - {
-
-            "without options" {
-                val regex = Regex("acme.*corp")
-                bson.dump(RegexSerializer, regex) shouldBe byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) }, // CString, size omitted
-                    0 // Options; Nothing
-                )
-            }
-
-            "with options" {
-                val regex =
-                    Regex(
-                        "acme.*corp", setOf(
-                            RegexOption.IGNORE_CASE,
-                            RegexOption.MULTILINE,
-                            RegexOption.LITERAL,
-                            RegexOption.UNIX_LINES,
-                            RegexOption.COMMENTS,
-                            RegexOption.DOT_MATCHES_ALL,
-                            RegexOption.CANON_EQ
-                        )
-                    )
-                bson.dump(RegexSerializer, regex) shouldBe byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) },
-                    *bytes(regex.options.asEmbedded().toSortedSet().joinToString("")).let { it.sliceArray(4 until it.size) }
-                )
-            }
-
-            "a hard one" {
-                val regex = Regex(
-                    "[+-]?(\\d+(\\.\\d+)?|\\.\\d+)([eE][+-]?\\d+)?", setOf(
-                        RegexOption.IGNORE_CASE,
-                        RegexOption.MULTILINE,
-                        RegexOption.UNIX_LINES,
-                        RegexOption.COMMENTS,
-                        RegexOption.DOT_MATCHES_ALL
-                    )
-                )
-                bson.dump(
-                    RegexSerializer, regex
-                ) shouldBe byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) },
-                    *bytes(regex.options.asEmbedded().toSortedSet().joinToString("")).let { it.sliceArray(4 until it.size) }
-                )
-            }
-        }
-
-        "enum kind" {
-            val notFound = HttpError.NOT_FOUND
-            val error = HttpError.INTERNAL_SERVER_ERROR
-
-            bson.dump(HttpError.serializer(), notFound) shouldBe bytes(notFound.name)
-            bson.dump(HttpError.serializer(), error) shouldBe bytes(error.name)
         }
 
     }

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/encoders/BsonValuePrimitiveTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/encoders/BsonValuePrimitiveTest.kt
@@ -8,7 +8,6 @@ import io.kotest.matchers.shouldBe
 import org.bson.*
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
-import java.nio.ByteBuffer
 import java.time.Clock
 import kotlin.random.Random
 
@@ -90,111 +89,6 @@ class BsonValuePrimitiveTest : FreeSpec({
         "bson string" {
             val str = BsonString("hello")
             bson.toBson(BsonValueSerializer, str) shouldBe str
-        }
-
-    }
-
-    "dump" - {
-
-        fun bytes(value: Int): ByteArray = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(value).array().reversedArray()
-        fun bytes(value: String): ByteArray = byteArrayOf(
-            *ByteBuffer.allocate(4).putInt(value.length + 1).array().reversedArray(),
-            *value.toByteArray(),
-            0
-        )
-
-        fun bytes(value: Long): ByteArray = ByteBuffer.allocate(Long.SIZE_BYTES).putLong(value).array().reversedArray()
-        fun bytes(value: Double): ByteArray = ByteBuffer.allocate(8).putDouble(value).array().reversedArray()
-
-        "bson binary" {
-            val binary = BsonBinary(Random.nextBytes(100))
-            bson.dump(BsonValueSerializer, binary) shouldBe byteArrayOf(
-                *bytes(binary.data.size),
-                binary.type,
-                *binary.data
-            )
-        }
-
-        "bson boolean" {
-            val bool = BsonBoolean(Random.nextBoolean())
-            bson.dump(BsonValueSerializer, bool) shouldBe byteArrayOf(
-                if (bool.value) 1 else 0
-            )
-        }
-
-        "bson date-time" {
-            val t = BsonDateTime(Clock.systemUTC().millis())
-            bson.dump(BsonValueSerializer, t) shouldBe bytes(t.value)
-        }
-
-        "bson decimal-128" {
-            val decimal = BsonDecimal128(Decimal128(Random.nextLong()))
-            bson.dump(BsonValueSerializer, decimal) shouldBe byteArrayOf(
-                *bytes(decimal.value.low),
-                *bytes(decimal.value.high)
-            )
-        }
-
-        "bson double" {
-            val d = BsonDouble(Random.nextDouble())
-            bson.dump(BsonValueSerializer, d) shouldBe bytes(d.value)
-        }
-
-        "bson int-32" {
-            val i = BsonInt32(Random.nextInt())
-            bson.dump(BsonValueSerializer, i) shouldBe bytes(i.value)
-        }
-
-        "bson int-64" {
-            val l = BsonInt64(Random.nextLong())
-            bson.dump(BsonValueSerializer, l) shouldBe bytes(l.value)
-        }
-
-        "bson java-script" {
-            val js = BsonJavaScript("main() {}")
-            bson.dump(BsonValueSerializer, js) shouldBe bytes(js.code)
-        }
-
-        "bson null" {
-            bson.dump(BsonValueSerializer, BsonNull.VALUE) shouldBe byteArrayOf()
-        }
-
-        "bson object-id" {
-            val id = BsonObjectId(ObjectId())
-            bson.dump(BsonValueSerializer, id) shouldBe id.value.toByteArray()
-        }
-
-        "bson regular expression" - {
-
-            "without options" {
-                val regex = BsonRegularExpression("acme.*corp")
-                bson.dump(BsonValueSerializer, regex) shouldBe byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) }, // CString, size omitted
-                    0 // Options; Nothing
-                )
-            }
-
-            "with options" {
-                val regex = BsonRegularExpression("acme.*corp", "imdxs")
-                bson.dump(BsonValueSerializer, regex) shouldBe byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) },
-                    *bytes(regex.options).let { it.sliceArray(4 until it.size) }
-                )
-            }
-
-            "a hard one" {
-                val regex = BsonRegularExpression("[+-]?(\\d+(\\.\\d+)?|\\.\\d+)([eE][+-]?\\d+)?", "imdxs")
-                bson.dump(BsonValueSerializer, regex) shouldBe byteArrayOf(
-                    *bytes(regex.pattern).let { it.sliceArray(4 until it.size) },
-                    *bytes(regex.options).let { it.sliceArray(4 until it.size) }
-                )
-            }
-
-        }
-
-        "bson string" {
-            val str = BsonString("hello")
-            bson.dump(BsonValueSerializer, str) shouldBe bytes(str.value)
         }
 
     }


### PR DESCRIPTION
- Removed `load` / `dump` primitive type support
- Updated README
- Added `loadBsonDocument`, `loadBsonArray` and `dumpBson` functions.
- Marked `load` non-primary function as deprecated.
- Added and applied universal bson value type checking function.
- Added `BsonDocument.toBsonArray` and `BsonArray.toBsonDocument` utility functions.
- Fixed the tests
