### PR TITLE
Regex options

### DIFF
--- a/mongodb/mongodb.gradle
+++ b/mongodb/mongodb.gradle
@@ -1,5 +1,3 @@
-import org.w3c.dom.Element
-
 plugins {
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version" // For test purposes
     id 'java-library'

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -128,39 +128,40 @@ class Bson(
         "Ports to the main load function; Loading primitives are no longer supported",
         ReplaceWith("load(deserializer, bytes)")
     )
+    @Suppress("UNUSED_PARAMETER")
     fun <T> load(deserializer: DeserializationStrategy<T>, bytes: ByteArray, type: BsonType): T {
         return load(deserializer, bytes)
     }
 
 }
 
-private val bsonTypesModule: SerialModule = serializersModuleOf(
-    mapOf(
-        BsonValue::class to BsonValueSerializer,
-        BsonDocument::class to BsonDocumentSerializer,
-        BsonArray::class to BsonArraySerializer,
-        BsonBinary::class to BsonPrimitiveSerializer,
-        BsonBoolean::class to BsonPrimitiveSerializer,
-        BsonDateTime::class to BsonPrimitiveSerializer,
-        BsonDecimal128::class to BsonPrimitiveSerializer,
-        BsonDouble::class to BsonPrimitiveSerializer,
-        BsonInt32::class to BsonPrimitiveSerializer,
-        BsonInt64::class to BsonPrimitiveSerializer,
-        BsonJavaScript::class to BsonPrimitiveSerializer,
-        BsonNull::class to BsonPrimitiveSerializer,
-        BsonNumber::class to BsonPrimitiveSerializer,
-        BsonObjectId::class to BsonPrimitiveSerializer,
-        BsonRegularExpression::class to BsonPrimitiveSerializer,
-        BsonString::class to BsonPrimitiveSerializer,
-        Binary::class to BinarySerializer,
-        ObjectId::class to ObjectIdSerializer,
-        Decimal128::class to Decimal128Serializer,
-        Regex::class to RegexSerializer,
-        Pattern::class to PatternSerializer
-    )
-)
-
 private val defaultBsonModule: SerialModule = SerializersModule {
-    include(bsonTypesModule)
+    include(
+        serializersModuleOf(
+            mapOf(
+                BsonValue::class to BsonValueSerializer,
+                BsonDocument::class to BsonDocumentSerializer,
+                BsonArray::class to BsonArraySerializer,
+                BsonBinary::class to BsonPrimitiveSerializer,
+                BsonBoolean::class to BsonPrimitiveSerializer,
+                BsonDateTime::class to BsonPrimitiveSerializer,
+                BsonDecimal128::class to BsonPrimitiveSerializer,
+                BsonDouble::class to BsonPrimitiveSerializer,
+                BsonInt32::class to BsonPrimitiveSerializer,
+                BsonInt64::class to BsonPrimitiveSerializer,
+                BsonJavaScript::class to BsonPrimitiveSerializer,
+                BsonNull::class to BsonPrimitiveSerializer,
+                BsonNumber::class to BsonPrimitiveSerializer,
+                BsonObjectId::class to BsonPrimitiveSerializer,
+                BsonRegularExpression::class to BsonPrimitiveSerializer,
+                BsonString::class to BsonPrimitiveSerializer,
+                Binary::class to BinarySerializer,
+                ObjectId::class to ObjectIdSerializer,
+                Decimal128::class to Decimal128Serializer,
+                Regex::class to RegexSerializer,
+                Pattern::class to PatternSerializer
+            )
+        )
+    )
     include(bsonTemporalModule)
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
@@ -7,6 +7,7 @@ import org.bson.BsonValue
 import org.bson.types.Binary
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
+import java.util.regex.Pattern
 
 /**
  * The [Decoder] instance which is passed to the [`deserialize`][kotlinx.serialization.KSerializer.deserialize] function when using [Bson].
@@ -51,6 +52,6 @@ interface BsonInput : Decoder, CompositeDecoder {
     /**
      * Read a [bson regular expression][org.bson.BsonRegularExpression] value.
      */
-    fun decodeRegularExpression(): Regex
+    fun decodeRegularExpression(): Pattern
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
@@ -5,7 +5,7 @@ import com.github.agcom.bson.serialization.BsonDecodingException
 import com.github.agcom.bson.serialization.utils.PRIMITIVE_TAG
 import com.github.agcom.bson.serialization.utils.fold
 import com.github.agcom.bson.serialization.utils.toBinary
-import com.github.agcom.bson.serialization.utils.toRegex
+import com.github.agcom.bson.serialization.utils.toPattern
 import kotlinx.serialization.*
 import kotlinx.serialization.internal.AbstractPolymorphicSerializer
 import kotlinx.serialization.internal.NamedValueDecoder
@@ -14,6 +14,7 @@ import org.bson.*
 import org.bson.types.Binary
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
+import java.util.regex.Pattern
 
 @OptIn(InternalSerializationApi::class)
 private sealed class AbstractBsonTreeInput(
@@ -69,7 +70,7 @@ private sealed class AbstractBsonTreeInput(
     override fun decodeDateTime(): Long = decodeTaggedDateTime(popTag())
     override fun decodeJavaScript(): String = decodeTaggedJavaScript(popTag())
     override fun decodeDecimal128(): Decimal128 = decodeTaggedDecimal128(popTag())
-    override fun decodeRegularExpression(): Regex = decodeTaggedRegularExpression(popTag())
+    override fun decodeRegularExpression(): Pattern = decodeTaggedRegularExpression(popTag())
 
     override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
         enumDescription.getElementIndexOrThrow(getValue(tag).asString().value)
@@ -90,7 +91,7 @@ private sealed class AbstractBsonTreeInput(
     private fun decodeTaggedDateTime(tag: String): Long = getValue(tag).asDateTime().value
     private fun decodeTaggedJavaScript(tag: String): String = getValue(tag).asJavaScript().code
     private fun decodeTaggedDecimal128(tag: String): Decimal128 = getValue(tag).asDecimal128().value
-    private fun decodeTaggedRegularExpression(tag: String): Regex = getValue(tag).asRegularExpression().toRegex()
+    private fun decodeTaggedRegularExpression(tag: String): Pattern = getValue(tag).asRegularExpression().toPattern()
 
 }
 

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
@@ -7,6 +7,7 @@ import org.bson.BsonValue
 import org.bson.types.Binary
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
+import java.util.regex.Pattern
 
 /**
  * The [Encoder] instance which is passed to [serialize][kotlinx.serialization.KSerializer.serialize] function when using [Bson].
@@ -48,6 +49,6 @@ interface BsonOutput : Encoder, CompositeEncoder {
     /**
      * Write a [bson regular expression][org.bson.BsonRegularExpression] value.
      */
-    fun encodeRegularExpression(regex: Regex)
+    fun encodeRegularExpression(pattern: Pattern)
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/TreeBsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/TreeBsonOutput.kt
@@ -15,6 +15,7 @@ import org.bson.BsonType.*
 import org.bson.types.Binary
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
+import java.util.regex.Pattern
 
 @OptIn(InternalSerializationApi::class)
 private sealed class AbstractBsonTreeOutput(
@@ -54,7 +55,7 @@ private sealed class AbstractBsonTreeOutput(
     private fun encodeTaggedDateTime(tag: String, value: Long) = putElement(tag, BsonDateTime(value))
     private fun encodeTaggedJavaScript(tag: String, value: String) = putElement(tag, BsonJavaScript(value))
     private fun encodeTaggedDecimal128(tag: String, value: Decimal128) = putElement(tag, BsonDecimal128(value))
-    private fun encodeTaggedRegularExpression(tag: String, value: Regex) =
+    private fun encodeTaggedRegularExpression(tag: String, value: Pattern) =
         putElement(tag, value.toBsonRegularExpression())
 
     private fun encodeTaggedBson(tag: String, value: BsonValue) = putElement(tag, value)
@@ -64,7 +65,7 @@ private sealed class AbstractBsonTreeOutput(
     override fun encodeDateTime(time: Long) = encodeTaggedDateTime(popTag(), time)
     override fun encodeJavaScript(code: String) = encodeTaggedJavaScript(popTag(), code)
     override fun encodeDecimal128(decimal: Decimal128) = encodeTaggedDecimal128(popTag(), decimal)
-    override fun encodeRegularExpression(regex: Regex) = encodeTaggedRegularExpression(popTag(), regex)
+    override fun encodeRegularExpression(pattern: Pattern) = encodeTaggedRegularExpression(popTag(), pattern)
 
     private fun checkClassDiscriminatorConflict(serializer: SerializationStrategy<*>) {
         if (bson.configuration.classDiscriminator in serializer.descriptor.elementNames())

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializer.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializer.kt
@@ -4,7 +4,7 @@ import com.github.agcom.bson.serialization.decoders.BsonInput
 import com.github.agcom.bson.serialization.encoders.BsonOutput
 import com.github.agcom.bson.serialization.utils.fold
 import com.github.agcom.bson.serialization.utils.toBinary
-import com.github.agcom.bson.serialization.utils.toRegex
+import com.github.agcom.bson.serialization.utils.toPattern
 import kotlinx.serialization.*
 import org.bson.*
 import org.bson.BsonType.*
@@ -57,7 +57,7 @@ object BsonPrimitiveSerializer : KSerializer<BsonValue> {
                     INT32 -> encoder.encodeInt(it.asInt32().value)
                     INT64 -> encoder.encodeLong(it.asInt64().value)
                     DECIMAL128 -> encoder.encodeDecimal128(it.asDecimal128().value)
-                    REGULAR_EXPRESSION -> encoder.encodeRegularExpression(it.asRegularExpression().toRegex())
+                    REGULAR_EXPRESSION -> encoder.encodeRegularExpression(it.asRegularExpression().toPattern())
                     else -> throw RuntimeException("Should not reach here")
                 }
             }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
@@ -140,7 +140,33 @@ object Decimal128Serializer : KSerializer<Decimal128> {
 }
 
 /**
+ * [Pattern] serializer.
+ *
+ * Corresponds to [BsonRegularExpression][org.bson.BsonRegularExpression] type.
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ * Uses [BsonOutput.encodeRegularExpression] / [BsonInput.decodeRegularExpression]
+ */
+@Serializer(Pattern::class)
+object PatternSerializer : KSerializer<Pattern> {
+
+    override val descriptor: SerialDescriptor = RegexSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Pattern) {
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeRegularExpression(value)
+    }
+
+    override fun deserialize(decoder: Decoder): Pattern {
+        decoder.verify(); decoder as BsonInput
+        return decoder.decodeRegularExpression()
+    }
+
+}
+
+/**
  * [Regex] serializer.
+ * Ports to [PatternSerializer]. Uses [toPattern] extension function when serializing and [toRegex] when deserializing.
  *
  * Corresponds to [BsonRegularExpression][org.bson.BsonRegularExpression] type.
  *
@@ -154,33 +180,11 @@ object RegexSerializer : KSerializer<Regex> {
         PrimitiveDescriptor(BsonRegularExpression::class.qualifiedName!!, PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: Regex) {
-        encoder.verify(); encoder as BsonOutput
-        encoder.encodeRegularExpression(value)
+        encoder.encode(PatternSerializer, value.toPattern())
     }
 
     override fun deserialize(decoder: Decoder): Regex {
-        decoder.verify(); decoder as BsonInput
-        return decoder.decodeRegularExpression()
+        return decoder.decode(PatternSerializer).toRegex()
     }
-
-}
-
-/**
- * [Pattern] serializer.
- * Ports to [RegexSerializer] using [toRegex] extension.
- *
- * Corresponds to [BsonRegularExpression][org.bson.BsonRegularExpression] type.
- *
- * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
- * Uses [BsonOutput.encodeRegularExpression] / [BsonInput.decodeRegularExpression]
- */
-@Serializer(Pattern::class)
-object PatternSerializer : KSerializer<Pattern> {
-
-    override val descriptor: SerialDescriptor = RegexSerializer.descriptor
-
-    override fun serialize(encoder: Encoder, value: Pattern) = encoder.encode(RegexSerializer, value.toRegex())
-
-    override fun deserialize(decoder: Decoder): Pattern = decoder.decode(RegexSerializer).toPattern()
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonRegularExpression.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonRegularExpression.kt
@@ -1,7 +1,12 @@
 package com.github.agcom.bson.serialization.utils
 
 import org.bson.BsonRegularExpression
-import kotlin.text.RegexOption.*
+import java.util.regex.Pattern
+
+/**
+ * Constructor like builder for [BsonRegularExpression] using Java [Pattern].
+ */
+operator fun BsonRegularExpression.invoke(pattern: Pattern): BsonRegularExpression = pattern.toBsonRegularExpression()
 
 /**
  * Constructor like builder for [BsonRegularExpression] using Kotlin [Regex].
@@ -9,44 +14,85 @@ import kotlin.text.RegexOption.*
 operator fun BsonRegularExpression.invoke(regex: Regex): BsonRegularExpression = regex.toBsonRegularExpression()
 
 /**
+ * Convert a Java [Pattern] into it's bson type class [BsonRegularExpression].
+ */
+fun Pattern.toBsonRegularExpression(): BsonRegularExpression =
+    BsonRegularExpression(pattern(), PatternUtils.flagsAsEmbedded(this))
+
+/**
  * Convert a Kotlin [Regex] into it's bson type class [BsonRegularExpression].
  */
-fun Regex.toBsonRegularExpression(): BsonRegularExpression = BsonRegularExpression(pattern, options.asEmbedded())
+fun Regex.toBsonRegularExpression(): BsonRegularExpression = toPattern().toBsonRegularExpression()
+
+/**
+ * Convert a [BsonRegularExpression] into Java [Pattern].
+ */
+fun BsonRegularExpression.toPattern(): Pattern = Pattern.compile(pattern, PatternUtils.embeddedAsFlags(options))
 
 /**
  * Convert a [BsonRegularExpression] into Kotlin [Regex].
  */
-fun BsonRegularExpression.toRegex(): Regex = Regex(pattern, options.toRegexOptions())
+fun BsonRegularExpression.toRegex(): Regex = toPattern().toRegex()
 
-/**
- * Ignores [LITERAL] and [CANON_EQ].
- * @return E.g. 'im' for [IGNORE_CASE] + [MULTILINE], empty string for empty set.
- */
-internal fun Set<RegexOption>.asEmbedded(): String {
-    val builder = StringBuilder(size)
-    forEach {
-        when (it) {
-            IGNORE_CASE -> 'i'
-            MULTILINE -> 'm'
-            LITERAL -> null // Runtime flag. Only used for parsing the pattern in specific way if needed.
-            UNIX_LINES -> 'd'
-            COMMENTS -> 'x'
-            DOT_MATCHES_ALL -> 's'
-            CANON_EQ -> null // Runtime flag. Used to restrict match algorithm if needed.
-        }?.let(builder::append)
-    }
-    return if (builder.isEmpty()) "" else builder.toString()
-}
+// Deals with the pattern options' conversations
+internal object PatternUtils {
 
-internal fun String.toRegexOptions(): Set<RegexOption> {
-    return map {
-        when (it) {
-            'i' -> IGNORE_CASE
-            'm' -> MULTILINE
-            'd' -> UNIX_LINES
-            'x' -> COMMENTS
-            's' -> DOT_MATCHES_ALL
-            else -> error("Invalid character '$it' for a regex option")
+    fun flagsAsEmbedded(pattern: Pattern): String = flagsAsEmbedded(pattern.flags())
+
+    fun embeddedAsFlags(regex: BsonRegularExpression): Int = embeddedAsFlags(regex.options)
+
+    fun flagsAsEmbedded(flags: Int): String {
+        var processedFlags = flags
+        val embedded = StringBuilder()
+
+        for (flag in PatternFlag.values()) {
+            if (flags and flag.mask > 0) {
+                embedded.append(flag.embedded)
+                processedFlags -= flag.mask
+            }
         }
-    }.toSet()
+
+        require(processedFlags <= 0) { "some flags couldn't be recognized" }
+        return embedded.toString()
+    }
+
+    fun embeddedAsFlags(embedded: String): Int {
+        if (embedded.isEmpty()) return 0
+
+        var flags = 0
+
+        for (c in embedded.toLowerCase()) {
+            val flag = PatternFlag(c) ?: throw IllegalArgumentException("Unrecognized flag 'c'")
+            flags = flags or flag.mask
+        }
+
+        return flags
+    }
+
+    private enum class PatternFlag(
+        val mask: Int,
+        val embedded: Char
+    ) {
+        CANON_EQ(Pattern.CANON_EQ, 'c'),
+        UNIX_LINES(Pattern.UNIX_LINES, 'd'),
+        GLOBAL(GLOBAL_FLAG, 'g'),
+        CASE_INSENSITIVE(Pattern.CASE_INSENSITIVE, 'i'),
+        MULTILINE(Pattern.MULTILINE, 'm'),
+        DOTALL(Pattern.DOTALL, 's'),
+        LITERAL(Pattern.LITERAL, 't'),
+        UNICODE_CASE(Pattern.UNICODE_CASE, 'u'),
+        COMMENTS(Pattern.COMMENTS, 'x');
+
+        companion object {
+            private val BY_EMBEDDED: Map<Char, PatternFlag> =
+                values().associateByTo(HashMap(values().size, 1.0f)) { it.embedded }
+
+            operator fun invoke(embedded: Char): PatternFlag? {
+                return BY_EMBEDDED[embedded]
+            }
+        }
+    }
+
+    private const val GLOBAL_FLAG = 256
+
 }

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
@@ -95,28 +95,22 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                         bson.toBson(Decimal128Serializer, decimal) shouldBe BsonDecimal128(decimal)
                     }
 
-                    "regular expresion" - {
+                    "pattern" {
+                        val flags =
+                            Pattern.CANON_EQ or Pattern.UNIX_LINES or 256 /* Global flag */ or Pattern.CASE_INSENSITIVE or Pattern.MULTILINE or Pattern.DOTALL or Pattern.LITERAL or Pattern.UNICODE_CASE or Pattern.COMMENTS
+                        val pattern = Pattern.compile("hello", flags)
+                        bson.toBson(PatternSerializer, pattern) shouldBe BsonRegularExpression(
+                            pattern.pattern(),
+                            "cdgimstux"
+                        )
+                    }
 
-                        "without options" {
-                            val regex = Regex("acme.*corp")
-                            bson.toBson(RegexSerializer, regex) shouldBe BsonRegularExpression(regex.pattern)
-                        }
-
-                        "with options" {
-                            val regex =
-                                Regex(
-                                    "acme.*corp", setOf(
-                                        RegexOption.IGNORE_CASE,
-                                        RegexOption.MULTILINE,
-                                        RegexOption.LITERAL,
-                                        RegexOption.UNIX_LINES,
-                                        RegexOption.COMMENTS,
-                                        RegexOption.DOT_MATCHES_ALL,
-                                        RegexOption.CANON_EQ
-                                    )
-                                )
-                            bson.toBson(RegexSerializer, regex) shouldBe BsonRegularExpression(regex.pattern, "imdxs")
-                        }
+                    "regex" {
+                        val regex = Regex("hello", RegexOption.values().toSet())
+                        bson.toBson(RegexSerializer, regex) shouldBe BsonRegularExpression(
+                            regex.pattern,
+                            "cdimstux"
+                        )
                     }
 
                     "enum kind" {
@@ -292,26 +286,23 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                         bson.fromBson(Decimal128Serializer, BsonDecimal128(decimal)) shouldBe decimal
                     }
 
-                    "regular expresion" - {
+                    "pattern" {
+                        val flags =
+                            Pattern.CANON_EQ or Pattern.UNIX_LINES or 256 /* Global flag */ or Pattern.CASE_INSENSITIVE or Pattern.MULTILINE or Pattern.DOTALL or Pattern.LITERAL or Pattern.UNICODE_CASE or Pattern.COMMENTS
+                        val pattern = Pattern.compile("hello", flags)
 
-                        "without options" {
-                            val regex = Regex("acme.*corp")
-                            bson.fromBson(RegexSerializer, BsonRegularExpression(regex.pattern)) shouldBe regex
-                        }
+                        val test =
+                            bson.fromBson(PatternSerializer, BsonRegularExpression(pattern.pattern(), "cdgimstux"))
+                        test.pattern() shouldBe pattern.pattern()
+                        test.flags() shouldBe pattern.flags()
+                    }
 
-                        "with options" {
-                            val regex =
-                                Regex(
-                                    "acme.*corp", setOf(
-                                        RegexOption.IGNORE_CASE,
-                                        RegexOption.MULTILINE,
-                                        RegexOption.UNIX_LINES,
-                                        RegexOption.COMMENTS,
-                                        RegexOption.DOT_MATCHES_ALL
-                                    )
-                                )
-                            bson.fromBson(RegexSerializer, BsonRegularExpression(regex.pattern, "imdxs")) shouldBe regex
-                        }
+                    "regex" {
+                        val regex = Regex("hello", RegexOption.values().toSet())
+
+                        val test = bson.fromBson(RegexSerializer, BsonRegularExpression(regex.pattern, "cdimstux"))
+                        test.pattern shouldBe regex.pattern
+                        test.options shouldBe regex.options
                     }
 
                     "enum kind" {

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
@@ -46,8 +46,8 @@ val testBsonValuePrimitives: List<BsonValue>
         BsonJavaScript("main() {}"),
         BsonNull.VALUE,
         BsonObjectId(ObjectId()),
-        BsonRegularExpression("acme.*corp"),
-        BsonRegularExpression("acme.*corp", "imdxs"),
+        BsonRegularExpression("hello"),
+        BsonRegularExpression("hello", "cdgimstux"),
         BsonString("hello")
     )
 

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/utils/BsonRegularExpressionTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/utils/BsonRegularExpressionTest.kt
@@ -93,7 +93,9 @@ class BsonRegularExpressionTest : FreeSpec({
         val bsonValue = BsonRegularExpression("hello", "cdgimstux")
         val expected = Regex(bsonValue.pattern, RegexOption.values().toSet())
 
-        bsonValue.toRegex() shouldBe expected
+        val test = bsonValue.toRegex()
+        test.pattern shouldBe expected.pattern
+        test.options shouldBe expected.options
     }
 
     "pattern to bson" {


### PR DESCRIPTION
## End user changes

- Fixed regex options, #46.
- Added builders for `BsonRegularExpression` using a `Pattern`
- Changed decoders/encoders to use `Pattern` class instead of `Regex`
	- `BsonInput.decodeRegularExpression` now returns a `Pattern` instead of `Regex`
	- `BsonOutput.encodeRegularExpression` now accepts a `Pattern` instead of `Regex`