### PR TITLE
Deprecated bson types support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently, only supports **Kotlinx serialization runtime 0.20.0**.
 
 ### Gradle
 
-- `*.gradle`
+- `*.gradle`:
 
   ```groovy
   repositories {
@@ -58,8 +58,6 @@ fun main() {
 ### Serialization functions
 
 The following functions can be found in the `com.github.agcom.bson.serialization.Bson` class.
-
-> Doesn't support some of deprecated bson types.
 
 - `toBson` and `fromBson`: The above example :point_up:.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fun main() {
 
 The following functions can be found in the `com.github.agcom.bson.serialization.Bson` class.
 
-> Doesn't support deprecated bson types.
+> Doesn't support some of deprecated bson types.
 
 - `toBson` and `fromBson`: The above example :point_up:.
 

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -151,6 +151,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(BsonMaxKeySerializer)
     contextual(BsonMinKeySerializer)
     contextual(BsonSymbolSerializer)
+    contextual(BsonUndefinedSerializer)
 
     contextual(BinarySerializer)
     contextual(ObjectIdSerializer)

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -148,6 +148,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(BsonStringSerializer)
     contextual(BsonDbPointerSerializer)
     contextual(BsonJavaScriptWithScopeSerializer)
+    contextual(BsonMaxKeySerializer)
 
     contextual(BinarySerializer)
     contextual(ObjectIdSerializer)
@@ -158,6 +159,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(ByteArraySerializer)
     contextual(UUIDSerializer())
     contextual(DateSerializer)
+    contextual(MaxKeySerializer)
 
     include(bsonTemporalModule)
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -152,6 +152,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(BsonMinKeySerializer)
     contextual(BsonSymbolSerializer)
     contextual(BsonUndefinedSerializer)
+    contextual(BsonTimestampSerializer)
 
     contextual(BinarySerializer)
     contextual(ObjectIdSerializer)

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -150,6 +150,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(BsonJavaScriptWithScopeSerializer)
     contextual(BsonMaxKeySerializer)
     contextual(BsonMinKeySerializer)
+    contextual(BsonSymbolSerializer)
 
     contextual(BinarySerializer)
     contextual(ObjectIdSerializer)

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -149,6 +149,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(BsonDbPointerSerializer)
     contextual(BsonJavaScriptWithScopeSerializer)
     contextual(BsonMaxKeySerializer)
+    contextual(BsonMinKeySerializer)
 
     contextual(BinarySerializer)
     contextual(ObjectIdSerializer)
@@ -160,6 +161,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(UUIDSerializer())
     contextual(DateSerializer)
     contextual(MaxKeySerializer)
+    contextual(MinKeySerializer)
 
     include(bsonTemporalModule)
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -146,6 +146,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(BsonObjectIdSerializer)
     contextual(BsonRegularExpressionSerializer)
     contextual(BsonStringSerializer)
+    contextual(BsonDbPointerSerializer)
 
     contextual(BinarySerializer)
     contextual(ObjectIdSerializer)

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/Bson.kt
@@ -147,6 +147,7 @@ private val defaultBsonModule: SerialModule = SerializersModule {
     contextual(BsonRegularExpressionSerializer)
     contextual(BsonStringSerializer)
     contextual(BsonDbPointerSerializer)
+    contextual(BsonJavaScriptWithScopeSerializer)
 
     contextual(BinarySerializer)
     contextual(ObjectIdSerializer)

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
@@ -3,10 +3,7 @@ package com.github.agcom.bson.serialization.decoders
 import com.github.agcom.bson.serialization.Bson
 import kotlinx.serialization.CompositeDecoder
 import kotlinx.serialization.Decoder
-import org.bson.BsonDbPointer
-import org.bson.BsonJavaScriptWithScope
-import org.bson.BsonUndefined
-import org.bson.BsonValue
+import org.bson.*
 import org.bson.types.*
 import java.util.regex.Pattern
 
@@ -84,5 +81,10 @@ interface BsonInput : Decoder, CompositeDecoder {
      * Read a [bson undefined][org.bson.BsonUndefined] value.
      */
     fun decodeUndefined(): BsonUndefined
+
+    /**
+     * Read a [bson timestamp][org.bson.BsonTimestamp] value.
+     */
+    fun decodeTimestamp(): BsonTimestamp
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
@@ -8,6 +8,7 @@ import org.bson.BsonJavaScriptWithScope
 import org.bson.BsonValue
 import org.bson.types.Binary
 import org.bson.types.Decimal128
+import org.bson.types.MaxKey
 import org.bson.types.ObjectId
 import java.util.regex.Pattern
 
@@ -65,5 +66,10 @@ interface BsonInput : Decoder, CompositeDecoder {
      * Read a [bson java script with scope][org.bson.BsonJavaScriptWithScope] value.
      */
     fun decodeJavaScriptWithScope(): BsonJavaScriptWithScope
+
+    /**
+     * Read a [bson max key][org.bson.BsonMaxKey] value.
+     */
+    fun decodeMaxKey(): MaxKey
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
@@ -6,10 +6,7 @@ import kotlinx.serialization.Decoder
 import org.bson.BsonDbPointer
 import org.bson.BsonJavaScriptWithScope
 import org.bson.BsonValue
-import org.bson.types.Binary
-import org.bson.types.Decimal128
-import org.bson.types.MaxKey
-import org.bson.types.ObjectId
+import org.bson.types.*
 import java.util.regex.Pattern
 
 /**
@@ -71,5 +68,10 @@ interface BsonInput : Decoder, CompositeDecoder {
      * Read a [bson max key][org.bson.BsonMaxKey] value.
      */
     fun decodeMaxKey(): MaxKey
+
+    /**
+     * Read a [bson min key][org.bson.BsonMinKey] value.
+     */
+    fun decodeMinKey(): MinKey
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
@@ -4,6 +4,7 @@ import com.github.agcom.bson.serialization.Bson
 import kotlinx.serialization.CompositeDecoder
 import kotlinx.serialization.Decoder
 import org.bson.BsonDbPointer
+import org.bson.BsonJavaScriptWithScope
 import org.bson.BsonValue
 import org.bson.types.Binary
 import org.bson.types.Decimal128
@@ -59,5 +60,10 @@ interface BsonInput : Decoder, CompositeDecoder {
      * Read a [bson db pointer][org.bson.BsonDbPointer] value.
      */
     fun decodeDbPointer(): BsonDbPointer
+
+    /**
+     * Read a [bson java script with scope][org.bson.BsonJavaScriptWithScope] value.
+     */
+    fun decodeJavaScriptWithScope(): BsonJavaScriptWithScope
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.CompositeDecoder
 import kotlinx.serialization.Decoder
 import org.bson.BsonDbPointer
 import org.bson.BsonJavaScriptWithScope
+import org.bson.BsonUndefined
 import org.bson.BsonValue
 import org.bson.types.*
 import java.util.regex.Pattern
@@ -78,5 +79,10 @@ interface BsonInput : Decoder, CompositeDecoder {
      * Read a [bson symbol][org.bson.BsonSymbol] value.
      */
     fun decodeSymbol(): String
+
+    /**
+     * Read a [bson undefined][org.bson.BsonUndefined] value.
+     */
+    fun decodeUndefined(): BsonUndefined
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
@@ -3,6 +3,7 @@ package com.github.agcom.bson.serialization.decoders
 import com.github.agcom.bson.serialization.Bson
 import kotlinx.serialization.CompositeDecoder
 import kotlinx.serialization.Decoder
+import org.bson.BsonDbPointer
 import org.bson.BsonValue
 import org.bson.types.Binary
 import org.bson.types.Decimal128
@@ -53,5 +54,10 @@ interface BsonInput : Decoder, CompositeDecoder {
      * Read a [bson regular expression][org.bson.BsonRegularExpression] value.
      */
     fun decodeRegularExpression(): Pattern
+
+    /**
+     * Read a [bson db pointer][org.bson.BsonDbPointer] value.
+     */
+    fun decodeDbPointer(): BsonDbPointer
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonInput.kt
@@ -74,4 +74,9 @@ interface BsonInput : Decoder, CompositeDecoder {
      */
     fun decodeMinKey(): MinKey
 
+    /**
+     * Read a [bson symbol][org.bson.BsonSymbol] value.
+     */
+    fun decodeSymbol(): String
+
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
@@ -71,6 +71,7 @@ private sealed class AbstractBsonTreeInput(
     override fun decodeJavaScript(): String = decodeTaggedJavaScript(popTag())
     override fun decodeDecimal128(): Decimal128 = decodeTaggedDecimal128(popTag())
     override fun decodeRegularExpression(): Pattern = decodeTaggedRegularExpression(popTag())
+    override fun decodeDbPointer(): BsonDbPointer = decodeTaggedDbPointer(popTag())
 
     override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
         enumDescription.getElementIndexOrThrow(getValue(tag).asString().value)
@@ -92,6 +93,7 @@ private sealed class AbstractBsonTreeInput(
     private fun decodeTaggedJavaScript(tag: String): String = getValue(tag).asJavaScript().code
     private fun decodeTaggedDecimal128(tag: String): Decimal128 = getValue(tag).asDecimal128().value
     private fun decodeTaggedRegularExpression(tag: String): Pattern = getValue(tag).asRegularExpression().toPattern()
+    private fun decodeTaggedDbPointer(tag: String): BsonDbPointer = getValue(tag).asDBPointer()
 
 }
 

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
@@ -11,10 +11,7 @@ import kotlinx.serialization.internal.AbstractPolymorphicSerializer
 import kotlinx.serialization.internal.NamedValueDecoder
 import kotlinx.serialization.modules.SerialModule
 import org.bson.*
-import org.bson.types.Binary
-import org.bson.types.Decimal128
-import org.bson.types.MaxKey
-import org.bson.types.ObjectId
+import org.bson.types.*
 import java.util.regex.Pattern
 
 @OptIn(InternalSerializationApi::class)
@@ -75,6 +72,7 @@ private sealed class AbstractBsonTreeInput(
     override fun decodeDbPointer(): BsonDbPointer = decodeTaggedDbPointer(popTag())
     override fun decodeJavaScriptWithScope(): BsonJavaScriptWithScope = decodeTaggerJavaScriptWithScope(popTag())
     override fun decodeMaxKey(): MaxKey = decodeTaggerMaxKey(popTag())
+    override fun decodeMinKey(): MinKey = decodeTaggerMinKey(popTag())
 
     override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
         enumDescription.getElementIndexOrThrow(getValue(tag).asString().value)
@@ -103,6 +101,11 @@ private sealed class AbstractBsonTreeInput(
         it as? BsonMaxKey
             ?: throw BsonInvalidOperationException("Value expected to be of type ${BsonType.MAX_KEY} is of unexpected type ${it.bsonType}")
         MaxKey()
+    }
+    private fun decodeTaggerMinKey(tag: String): MinKey = getValue(tag).let {
+        it as? BsonMinKey
+            ?: throw BsonInvalidOperationException("Value expected to be of type ${BsonType.MIN_KEY} is of unexpected type ${it.bsonType}")
+        MinKey()
     }
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
@@ -70,9 +70,10 @@ private sealed class AbstractBsonTreeInput(
     override fun decodeDecimal128(): Decimal128 = decodeTaggedDecimal128(popTag())
     override fun decodeRegularExpression(): Pattern = decodeTaggedRegularExpression(popTag())
     override fun decodeDbPointer(): BsonDbPointer = decodeTaggedDbPointer(popTag())
-    override fun decodeJavaScriptWithScope(): BsonJavaScriptWithScope = decodeTaggerJavaScriptWithScope(popTag())
-    override fun decodeMaxKey(): MaxKey = decodeTaggerMaxKey(popTag())
-    override fun decodeMinKey(): MinKey = decodeTaggerMinKey(popTag())
+    override fun decodeJavaScriptWithScope(): BsonJavaScriptWithScope = decodeTaggedJavaScriptWithScope(popTag())
+    override fun decodeMaxKey(): MaxKey = decodeTaggedMaxKey(popTag())
+    override fun decodeMinKey(): MinKey = decodeTaggedMinKey(popTag())
+    override fun decodeSymbol(): String = decodeTaggedSymbol(popTag())
 
     override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
         enumDescription.getElementIndexOrThrow(getValue(tag).asString().value)
@@ -95,18 +96,22 @@ private sealed class AbstractBsonTreeInput(
     private fun decodeTaggedDecimal128(tag: String): Decimal128 = getValue(tag).asDecimal128().value
     private fun decodeTaggedRegularExpression(tag: String): Pattern = getValue(tag).asRegularExpression().toPattern()
     private fun decodeTaggedDbPointer(tag: String): BsonDbPointer = getValue(tag).asDBPointer()
-    private fun decodeTaggerJavaScriptWithScope(tag: String): BsonJavaScriptWithScope =
+    private fun decodeTaggedJavaScriptWithScope(tag: String): BsonJavaScriptWithScope =
         getValue(tag).asJavaScriptWithScope()
-    private fun decodeTaggerMaxKey(tag: String): MaxKey = getValue(tag).let {
+
+    private fun decodeTaggedMaxKey(tag: String): MaxKey = getValue(tag).let {
         it as? BsonMaxKey
             ?: throw BsonInvalidOperationException("Value expected to be of type ${BsonType.MAX_KEY} is of unexpected type ${it.bsonType}")
         MaxKey()
     }
-    private fun decodeTaggerMinKey(tag: String): MinKey = getValue(tag).let {
+
+    private fun decodeTaggedMinKey(tag: String): MinKey = getValue(tag).let {
         it as? BsonMinKey
             ?: throw BsonInvalidOperationException("Value expected to be of type ${BsonType.MIN_KEY} is of unexpected type ${it.bsonType}")
         MinKey()
     }
+
+    private fun decodeTaggedSymbol(tag: String): String = getValue(tag).asSymbol().symbol
 
 }
 

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
@@ -72,6 +72,7 @@ private sealed class AbstractBsonTreeInput(
     override fun decodeDecimal128(): Decimal128 = decodeTaggedDecimal128(popTag())
     override fun decodeRegularExpression(): Pattern = decodeTaggedRegularExpression(popTag())
     override fun decodeDbPointer(): BsonDbPointer = decodeTaggedDbPointer(popTag())
+    override fun decodeJavaScriptWithScope(): BsonJavaScriptWithScope = decodeTaggerJavaScriptWithScope(popTag())
 
     override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
         enumDescription.getElementIndexOrThrow(getValue(tag).asString().value)
@@ -94,6 +95,7 @@ private sealed class AbstractBsonTreeInput(
     private fun decodeTaggedDecimal128(tag: String): Decimal128 = getValue(tag).asDecimal128().value
     private fun decodeTaggedRegularExpression(tag: String): Pattern = getValue(tag).asRegularExpression().toPattern()
     private fun decodeTaggedDbPointer(tag: String): BsonDbPointer = getValue(tag).asDBPointer()
+    private fun decodeTaggerJavaScriptWithScope(tag: String): BsonJavaScriptWithScope = getValue(tag).asJavaScriptWithScope()
 
 }
 

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
@@ -74,6 +74,7 @@ private sealed class AbstractBsonTreeInput(
     override fun decodeMaxKey(): MaxKey = decodeTaggedMaxKey(popTag())
     override fun decodeMinKey(): MinKey = decodeTaggedMinKey(popTag())
     override fun decodeSymbol(): String = decodeTaggedSymbol(popTag())
+    override fun decodeUndefined(): BsonUndefined = decodeTaggedUndefined(popTag())
 
     override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
         enumDescription.getElementIndexOrThrow(getValue(tag).asString().value)
@@ -112,6 +113,10 @@ private sealed class AbstractBsonTreeInput(
     }
 
     private fun decodeTaggedSymbol(tag: String): String = getValue(tag).asSymbol().symbol
+    private fun decodeTaggedUndefined(tag: String): BsonUndefined = getValue(tag).let {
+        it as? BsonUndefined
+            ?: throw BsonInvalidOperationException("Value expected to be of type ${BsonType.UNDEFINED} is of unexpected type ${it.bsonType}")
+    }
 
 }
 

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/decoders/BsonTreeInput.kt
@@ -75,6 +75,7 @@ private sealed class AbstractBsonTreeInput(
     override fun decodeMinKey(): MinKey = decodeTaggedMinKey(popTag())
     override fun decodeSymbol(): String = decodeTaggedSymbol(popTag())
     override fun decodeUndefined(): BsonUndefined = decodeTaggedUndefined(popTag())
+    override fun decodeTimestamp(): BsonTimestamp = decodeTaggedTimestamp(popTag())
 
     override fun decodeTaggedEnum(tag: String, enumDescription: SerialDescriptor): Int =
         enumDescription.getElementIndexOrThrow(getValue(tag).asString().value)
@@ -117,6 +118,8 @@ private sealed class AbstractBsonTreeInput(
         it as? BsonUndefined
             ?: throw BsonInvalidOperationException("Value expected to be of type ${BsonType.UNDEFINED} is of unexpected type ${it.bsonType}")
     }
+
+    private fun decodeTaggedTimestamp(tag: String): BsonTimestamp = getValue(tag).asTimestamp()
 
 }
 

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
@@ -6,10 +6,7 @@ import kotlinx.serialization.Encoder
 import org.bson.BsonDbPointer
 import org.bson.BsonJavaScriptWithScope
 import org.bson.BsonValue
-import org.bson.types.Binary
-import org.bson.types.Decimal128
-import org.bson.types.MaxKey
-import org.bson.types.ObjectId
+import org.bson.types.*
 import java.util.regex.Pattern
 
 /**
@@ -68,5 +65,10 @@ interface BsonOutput : Encoder, CompositeEncoder {
      * Write a [bson max key][org.bson.BsonMaxKey] value.
      */
     fun encodeMaxKey(maxKey: MaxKey = MaxKey())
+
+    /**
+     * Write a [bson min key][org.bson.BsonMinKey] value.
+     */
+    fun encodeMinKey(minKey: MinKey = MinKey())
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
@@ -71,4 +71,9 @@ interface BsonOutput : Encoder, CompositeEncoder {
      */
     fun encodeMinKey(minKey: MinKey = MinKey())
 
+    /**
+     * Write a [bson symbol][org.bson.BsonSymbol] value.
+     */
+    fun encodeSymbol(symbol: String)
+
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
@@ -8,6 +8,7 @@ import org.bson.BsonJavaScriptWithScope
 import org.bson.BsonValue
 import org.bson.types.Binary
 import org.bson.types.Decimal128
+import org.bson.types.MaxKey
 import org.bson.types.ObjectId
 import java.util.regex.Pattern
 
@@ -62,5 +63,10 @@ interface BsonOutput : Encoder, CompositeEncoder {
      * Write a [bson java script with scope][org.bson.BsonJavaScriptWithScope] value.
      */
     fun encodeJavaScriptWithScope(jsWithScope: BsonJavaScriptWithScope)
+
+    /**
+     * Write a [bson max key][org.bson.BsonMaxKey] value.
+     */
+    fun encodeMaxKey(maxKey: MaxKey = MaxKey())
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
@@ -3,10 +3,7 @@ package com.github.agcom.bson.serialization.encoders
 import com.github.agcom.bson.serialization.Bson
 import kotlinx.serialization.CompositeEncoder
 import kotlinx.serialization.Encoder
-import org.bson.BsonDbPointer
-import org.bson.BsonJavaScriptWithScope
-import org.bson.BsonUndefined
-import org.bson.BsonValue
+import org.bson.*
 import org.bson.types.*
 import java.util.regex.Pattern
 
@@ -81,5 +78,10 @@ interface BsonOutput : Encoder, CompositeEncoder {
      * Write a [bson undefined][org.bson.BsonUndefined] value.
      */
     fun encodeUndefined(undefined: BsonUndefined = BsonUndefined())
+
+    /**
+     * Write a [bson timestamp][org.bson.BsonTimestamp] value.
+     */
+    fun encodeTimestamp(timestamp: BsonTimestamp)
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
@@ -4,6 +4,7 @@ import com.github.agcom.bson.serialization.Bson
 import kotlinx.serialization.CompositeEncoder
 import kotlinx.serialization.Encoder
 import org.bson.BsonDbPointer
+import org.bson.BsonJavaScriptWithScope
 import org.bson.BsonValue
 import org.bson.types.Binary
 import org.bson.types.Decimal128
@@ -56,5 +57,10 @@ interface BsonOutput : Encoder, CompositeEncoder {
      * Write a [bson db pointer][org.bson.BsonDbPointer] value.
      */
     fun encodeDbPointer(pointer: BsonDbPointer)
+
+    /**
+     * Write a [bson java script with scope][org.bson.BsonJavaScriptWithScope] value.
+     */
+    fun encodeJavaScriptWithScope(jsWithScope: BsonJavaScriptWithScope)
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.CompositeEncoder
 import kotlinx.serialization.Encoder
 import org.bson.BsonDbPointer
 import org.bson.BsonJavaScriptWithScope
+import org.bson.BsonUndefined
 import org.bson.BsonValue
 import org.bson.types.*
 import java.util.regex.Pattern
@@ -75,5 +76,10 @@ interface BsonOutput : Encoder, CompositeEncoder {
      * Write a [bson symbol][org.bson.BsonSymbol] value.
      */
     fun encodeSymbol(symbol: String)
+
+    /**
+     * Write a [bson undefined][org.bson.BsonUndefined] value.
+     */
+    fun encodeUndefined(undefined: BsonUndefined = BsonUndefined())
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonOutput.kt
@@ -3,6 +3,7 @@ package com.github.agcom.bson.serialization.encoders
 import com.github.agcom.bson.serialization.Bson
 import kotlinx.serialization.CompositeEncoder
 import kotlinx.serialization.Encoder
+import org.bson.BsonDbPointer
 import org.bson.BsonValue
 import org.bson.types.Binary
 import org.bson.types.Decimal128
@@ -50,5 +51,10 @@ interface BsonOutput : Encoder, CompositeEncoder {
      * Write a [bson regular expression][org.bson.BsonRegularExpression] value.
      */
     fun encodeRegularExpression(pattern: Pattern)
+
+    /**
+     * Write a [bson db pointer][org.bson.BsonDbPointer] value.
+     */
+    fun encodeDbPointer(pointer: BsonDbPointer)
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
@@ -61,8 +61,10 @@ private sealed class AbstractBsonTreeOutput(
 
     @Suppress("UNUSED_PARAMETER")
     private fun encodeTaggedMaxKey(tag: String, value: MaxKey) = putElement(tag, BsonMaxKey())
+
     @Suppress("UNUSED_PARAMETER")
     private fun encodeTaggedMinKey(tag: String, value: MinKey) = putElement(tag, BsonMinKey())
+    private fun encodeTaggedSymbol(tag: String, value: String) = putElement(tag, BsonSymbol(value))
 
     private fun encodeTaggedBson(tag: String, value: BsonValue) = putElement(tag, value)
 
@@ -78,6 +80,7 @@ private sealed class AbstractBsonTreeOutput(
 
     override fun encodeMaxKey(maxKey: MaxKey) = encodeTaggedMaxKey(popTag(), maxKey)
     override fun encodeMinKey(minKey: MinKey) = encodeTaggedMinKey(popTag(), minKey)
+    override fun encodeSymbol(symbol: String) = encodeTaggedSymbol(popTag(), symbol)
 
     private fun checkClassDiscriminatorConflict(serializer: SerializationStrategy<*>) {
         if (bson.configuration.classDiscriminator in serializer.descriptor.elementNames())

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
@@ -12,10 +12,7 @@ import kotlinx.serialization.internal.NamedValueEncoder
 import kotlinx.serialization.modules.SerialModule
 import org.bson.*
 import org.bson.BsonType.*
-import org.bson.types.Binary
-import org.bson.types.Decimal128
-import org.bson.types.MaxKey
-import org.bson.types.ObjectId
+import org.bson.types.*
 import java.util.regex.Pattern
 
 @OptIn(InternalSerializationApi::class)
@@ -58,10 +55,14 @@ private sealed class AbstractBsonTreeOutput(
     private fun encodeTaggedDecimal128(tag: String, value: Decimal128) = putElement(tag, BsonDecimal128(value))
     private fun encodeTaggedRegularExpression(tag: String, value: Pattern) =
         putElement(tag, value.toBsonRegularExpression())
+
     private fun encodeTaggedDbPointer(tag: String, value: BsonDbPointer) = putElement(tag, value)
     private fun encodeTaggerJavaScriptWithScope(tag: String, value: BsonJavaScriptWithScope) = putElement(tag, value)
+
     @Suppress("UNUSED_PARAMETER")
     private fun encodeTaggedMaxKey(tag: String, value: MaxKey) = putElement(tag, BsonMaxKey())
+    @Suppress("UNUSED_PARAMETER")
+    private fun encodeTaggedMinKey(tag: String, value: MinKey) = putElement(tag, BsonMinKey())
 
     private fun encodeTaggedBson(tag: String, value: BsonValue) = putElement(tag, value)
 
@@ -72,8 +73,11 @@ private sealed class AbstractBsonTreeOutput(
     override fun encodeDecimal128(decimal: Decimal128) = encodeTaggedDecimal128(popTag(), decimal)
     override fun encodeRegularExpression(pattern: Pattern) = encodeTaggedRegularExpression(popTag(), pattern)
     override fun encodeDbPointer(pointer: BsonDbPointer) = encodeTaggedDbPointer(popTag(), pointer)
-    override fun encodeJavaScriptWithScope(jsWithScope: BsonJavaScriptWithScope) = encodeTaggerJavaScriptWithScope(popTag(), jsWithScope)
+    override fun encodeJavaScriptWithScope(jsWithScope: BsonJavaScriptWithScope) =
+        encodeTaggerJavaScriptWithScope(popTag(), jsWithScope)
+
     override fun encodeMaxKey(maxKey: MaxKey) = encodeTaggedMaxKey(popTag(), maxKey)
+    override fun encodeMinKey(minKey: MinKey) = encodeTaggedMinKey(popTag(), minKey)
 
     private fun checkClassDiscriminatorConflict(serializer: SerializationStrategy<*>) {
         if (bson.configuration.classDiscriminator in serializer.descriptor.elementNames())

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
@@ -14,6 +14,7 @@ import org.bson.*
 import org.bson.BsonType.*
 import org.bson.types.Binary
 import org.bson.types.Decimal128
+import org.bson.types.MaxKey
 import org.bson.types.ObjectId
 import java.util.regex.Pattern
 
@@ -59,6 +60,8 @@ private sealed class AbstractBsonTreeOutput(
         putElement(tag, value.toBsonRegularExpression())
     private fun encodeTaggedDbPointer(tag: String, value: BsonDbPointer) = putElement(tag, value)
     private fun encodeTaggerJavaScriptWithScope(tag: String, value: BsonJavaScriptWithScope) = putElement(tag, value)
+    @Suppress("UNUSED_PARAMETER")
+    private fun encodeTaggedMaxKey(tag: String, value: MaxKey) = putElement(tag, BsonMaxKey())
 
     private fun encodeTaggedBson(tag: String, value: BsonValue) = putElement(tag, value)
 
@@ -70,6 +73,7 @@ private sealed class AbstractBsonTreeOutput(
     override fun encodeRegularExpression(pattern: Pattern) = encodeTaggedRegularExpression(popTag(), pattern)
     override fun encodeDbPointer(pointer: BsonDbPointer) = encodeTaggedDbPointer(popTag(), pointer)
     override fun encodeJavaScriptWithScope(jsWithScope: BsonJavaScriptWithScope) = encodeTaggerJavaScriptWithScope(popTag(), jsWithScope)
+    override fun encodeMaxKey(maxKey: MaxKey) = encodeTaggedMaxKey(popTag(), maxKey)
 
     private fun checkClassDiscriminatorConflict(serializer: SerializationStrategy<*>) {
         if (bson.configuration.classDiscriminator in serializer.descriptor.elementNames())

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
@@ -58,6 +58,7 @@ private sealed class AbstractBsonTreeOutput(
     private fun encodeTaggedRegularExpression(tag: String, value: Pattern) =
         putElement(tag, value.toBsonRegularExpression())
     private fun encodeTaggedDbPointer(tag: String, value: BsonDbPointer) = putElement(tag, value)
+    private fun encodeTaggerJavaScriptWithScope(tag: String, value: BsonJavaScriptWithScope) = putElement(tag, value)
 
     private fun encodeTaggedBson(tag: String, value: BsonValue) = putElement(tag, value)
 
@@ -68,6 +69,7 @@ private sealed class AbstractBsonTreeOutput(
     override fun encodeDecimal128(decimal: Decimal128) = encodeTaggedDecimal128(popTag(), decimal)
     override fun encodeRegularExpression(pattern: Pattern) = encodeTaggedRegularExpression(popTag(), pattern)
     override fun encodeDbPointer(pointer: BsonDbPointer) = encodeTaggedDbPointer(popTag(), pointer)
+    override fun encodeJavaScriptWithScope(jsWithScope: BsonJavaScriptWithScope) = encodeTaggerJavaScriptWithScope(popTag(), jsWithScope)
 
     private fun checkClassDiscriminatorConflict(serializer: SerializationStrategy<*>) {
         if (bson.configuration.classDiscriminator in serializer.descriptor.elementNames())

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
@@ -65,6 +65,7 @@ private sealed class AbstractBsonTreeOutput(
     @Suppress("UNUSED_PARAMETER")
     private fun encodeTaggedMinKey(tag: String, value: MinKey) = putElement(tag, BsonMinKey())
     private fun encodeTaggedSymbol(tag: String, value: String) = putElement(tag, BsonSymbol(value))
+    private fun encodeTaggedUndefined(tag: String, value: BsonUndefined) = putElement(tag, value)
 
     private fun encodeTaggedBson(tag: String, value: BsonValue) = putElement(tag, value)
 
@@ -81,6 +82,7 @@ private sealed class AbstractBsonTreeOutput(
     override fun encodeMaxKey(maxKey: MaxKey) = encodeTaggedMaxKey(popTag(), maxKey)
     override fun encodeMinKey(minKey: MinKey) = encodeTaggedMinKey(popTag(), minKey)
     override fun encodeSymbol(symbol: String) = encodeTaggedSymbol(popTag(), symbol)
+    override fun encodeUndefined(undefined: BsonUndefined) = encodeTaggedUndefined(popTag(), undefined)
 
     private fun checkClassDiscriminatorConflict(serializer: SerializationStrategy<*>) {
         if (bson.configuration.classDiscriminator in serializer.descriptor.elementNames())

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
@@ -66,6 +66,7 @@ private sealed class AbstractBsonTreeOutput(
     private fun encodeTaggedMinKey(tag: String, value: MinKey) = putElement(tag, BsonMinKey())
     private fun encodeTaggedSymbol(tag: String, value: String) = putElement(tag, BsonSymbol(value))
     private fun encodeTaggedUndefined(tag: String, value: BsonUndefined) = putElement(tag, value)
+    private fun encodeTaggedTimestamp(tag: String, value: BsonTimestamp) = putElement(tag, value)
 
     private fun encodeTaggedBson(tag: String, value: BsonValue) = putElement(tag, value)
 
@@ -83,6 +84,7 @@ private sealed class AbstractBsonTreeOutput(
     override fun encodeMinKey(minKey: MinKey) = encodeTaggedMinKey(popTag(), minKey)
     override fun encodeSymbol(symbol: String) = encodeTaggedSymbol(popTag(), symbol)
     override fun encodeUndefined(undefined: BsonUndefined) = encodeTaggedUndefined(popTag(), undefined)
+    override fun encodeTimestamp(timestamp: BsonTimestamp) = encodeTaggedTimestamp(popTag(), timestamp)
 
     private fun checkClassDiscriminatorConflict(serializer: SerializationStrategy<*>) {
         if (bson.configuration.classDiscriminator in serializer.descriptor.elementNames())

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/encoders/BsonTreeOutput.kt
@@ -57,6 +57,7 @@ private sealed class AbstractBsonTreeOutput(
     private fun encodeTaggedDecimal128(tag: String, value: Decimal128) = putElement(tag, BsonDecimal128(value))
     private fun encodeTaggedRegularExpression(tag: String, value: Pattern) =
         putElement(tag, value.toBsonRegularExpression())
+    private fun encodeTaggedDbPointer(tag: String, value: BsonDbPointer) = putElement(tag, value)
 
     private fun encodeTaggedBson(tag: String, value: BsonValue) = putElement(tag, value)
 
@@ -66,6 +67,7 @@ private sealed class AbstractBsonTreeOutput(
     override fun encodeJavaScript(code: String) = encodeTaggedJavaScript(popTag(), code)
     override fun encodeDecimal128(decimal: Decimal128) = encodeTaggedDecimal128(popTag(), decimal)
     override fun encodeRegularExpression(pattern: Pattern) = encodeTaggedRegularExpression(popTag(), pattern)
+    override fun encodeDbPointer(pointer: BsonDbPointer) = encodeTaggedDbPointer(popTag(), pointer)
 
     private fun checkClassDiscriminatorConflict(serializer: SerializationStrategy<*>) {
         if (bson.configuration.classDiscriminator in serializer.descriptor.elementNames())

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
@@ -28,8 +28,6 @@ import org.bson.types.MinKey
  * - [BsonMinKey]
  * - [BsonSymbol]
  * - [BsonUndefined]
- *
- * Note: Doesn't support some of deprecated or internal types:
  * - [BsonJavaScriptWithScope]
  * - [BsonTimestamp]
  *
@@ -82,6 +80,7 @@ object BsonPrimitiveSerializer : KSerializer<BsonValue> {
                         BsonUndefinedSerializer, it as? BsonUndefined
                             ?: throw BsonInvalidOperationException("Value expected to be of type ${UNDEFINED} is of unexpected type ${it.bsonType}")
                     )
+                    TIMESTAMP -> encoder.encode(BsonTimestampSerializer, it.asTimestamp())
                     else -> throw RuntimeException("Should not reach here")
                 }
             }
@@ -493,6 +492,28 @@ object BsonUndefinedSerializer : KSerializer<BsonUndefined> {
     override fun deserialize(decoder: Decoder): BsonUndefined {
         decoder.verify(); decoder as BsonInput
         return decoder.decodeUndefined()
+    }
+
+}
+
+/**
+ * External serializer for [BsonTimestamp].
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object BsonTimestampSerializer : KSerializer<BsonTimestamp> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveDescriptor(BsonTimestamp::class.qualifiedName!!, PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: BsonTimestamp) {
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeTimestamp(value)
+    }
+
+    override fun deserialize(decoder: Decoder): BsonTimestamp {
+        decoder.verify(); decoder as BsonInput
+        return decoder.decodeTimestamp()
     }
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
@@ -27,11 +27,11 @@ import org.bson.types.MinKey
  * - [BsonMaxKey]
  * - [BsonMinKey]
  * - [BsonSymbol]
+ * - [BsonUndefined]
  *
  * Note: Doesn't support some of deprecated or internal types:
  * - [BsonJavaScriptWithScope]
  * - [BsonTimestamp]
- * - [BsonUndefined]
  *
  * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
  */
@@ -78,6 +78,10 @@ object BsonPrimitiveSerializer : KSerializer<BsonValue> {
                             ?: throw BsonInvalidOperationException("Value expected to be of type $MIN_KEY is of unexpected type ${it.bsonType}")
                     )
                     SYMBOL -> encoder.encode(BsonSymbolSerializer, it.asSymbol())
+                    UNDEFINED -> encoder.encode(
+                        BsonUndefinedSerializer, it as? BsonUndefined
+                            ?: throw BsonInvalidOperationException("Value expected to be of type ${UNDEFINED} is of unexpected type ${it.bsonType}")
+                    )
                     else -> throw RuntimeException("Should not reach here")
                 }
             }
@@ -467,6 +471,28 @@ object BsonSymbolSerializer : KSerializer<BsonSymbol> {
     override fun deserialize(decoder: Decoder): BsonSymbol {
         decoder.verify(); decoder as BsonInput
         return BsonSymbol(decoder.decodeSymbol())
+    }
+
+}
+
+/**
+ * External serializer for [BsonUndefined].
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object BsonUndefinedSerializer : KSerializer<BsonUndefined> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveDescriptor(BsonUndefined::class.qualifiedName!!, PrimitiveKind.BYTE)
+
+    override fun serialize(encoder: Encoder, value: BsonUndefined) {
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeUndefined(value)
+    }
+
+    override fun deserialize(decoder: Decoder): BsonUndefined {
+        decoder.verify(); decoder as BsonInput
+        return decoder.decodeUndefined()
     }
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
@@ -6,6 +6,7 @@ import com.github.agcom.bson.serialization.utils.*
 import kotlinx.serialization.*
 import org.bson.*
 import org.bson.BsonType.*
+import org.bson.types.MaxKey
 
 /**
  * External serializer for bson primitive types (anything other than [BsonDocument] and [BsonArray]):
@@ -65,6 +66,7 @@ object BsonPrimitiveSerializer : KSerializer<BsonValue> {
                         BsonJavaScriptWithScopeSerializer,
                         it.asJavaScriptWithScope()
                     )
+                    MAX_KEY -> encoder.encode(BsonMaxKeySerializer, it as? BsonMaxKey ?: throw BsonInvalidOperationException("Value expected to be of type ${BsonType.MAX_KEY} is of unexpected type ${it.bsonType}"))
                     else -> throw RuntimeException("Should not reach here")
                 }
             }
@@ -388,4 +390,26 @@ object BsonJavaScriptWithScopeSerializer : KSerializer<BsonJavaScriptWithScope> 
         decoder.verify(); decoder as BsonInput
         return decoder.decodeJavaScriptWithScope()
     }
+}
+
+/**
+ * External serializer for [BsonMaxKey].
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object BsonMaxKeySerializer : KSerializer<BsonMaxKey> {
+
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor(BsonMaxKey::class.qualifiedName!!, PrimitiveKind.BYTE)
+
+    override fun serialize(encoder: Encoder, value: BsonMaxKey) {
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeMaxKey(MaxKey())
+    }
+
+    override fun deserialize(decoder: Decoder): BsonMaxKey {
+        decoder.verify(); decoder as BsonInput
+        decoder.decodeMaxKey()
+        return BsonMaxKey()
+    }
+
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
@@ -61,6 +61,10 @@ object BsonPrimitiveSerializer : KSerializer<BsonValue> {
                     DECIMAL128 -> encoder.encode(BsonDecimal128Serializer, it.asDecimal128())
                     REGULAR_EXPRESSION -> encoder.encode(BsonRegularExpressionSerializer, it.asRegularExpression())
                     DB_POINTER -> encoder.encode(BsonDbPointerSerializer, it.asDBPointer())
+                    JAVASCRIPT_WITH_SCOPE -> encoder.encode(
+                        BsonJavaScriptWithScopeSerializer,
+                        it.asJavaScriptWithScope()
+                    )
                     else -> throw RuntimeException("Should not reach here")
                 }
             }
@@ -363,4 +367,25 @@ object BsonDbPointerSerializer : KSerializer<BsonDbPointer> {
         return decoder.decodeDbPointer()
     }
 
+}
+
+/**
+ * External serializer for [BsonJavaScriptWithScope].
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object BsonJavaScriptWithScopeSerializer : KSerializer<BsonJavaScriptWithScope> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveDescriptor(BsonJavaScriptWithScope::class.qualifiedName!!, PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: BsonJavaScriptWithScope) {
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeJavaScriptWithScope(value)
+    }
+
+    override fun deserialize(decoder: Decoder): BsonJavaScriptWithScope {
+        decoder.verify(); decoder as BsonInput
+        return decoder.decodeJavaScriptWithScope()
+    }
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
@@ -26,10 +26,10 @@ import org.bson.types.MinKey
  * - [BsonDbPointer]
  * - [BsonMaxKey]
  * - [BsonMinKey]
+ * - [BsonSymbol]
  *
  * Note: Doesn't support some of deprecated or internal types:
  * - [BsonJavaScriptWithScope]
- * - [BsonSymbol]
  * - [BsonTimestamp]
  * - [BsonUndefined]
  *
@@ -77,6 +77,7 @@ object BsonPrimitiveSerializer : KSerializer<BsonValue> {
                         it as? BsonMinKey
                             ?: throw BsonInvalidOperationException("Value expected to be of type $MIN_KEY is of unexpected type ${it.bsonType}")
                     )
+                    SYMBOL -> encoder.encode(BsonSymbolSerializer, it.asSymbol())
                     else -> throw RuntimeException("Should not reach here")
                 }
             }
@@ -444,6 +445,28 @@ object BsonMinKeySerializer : KSerializer<BsonMinKey> {
         decoder.verify(); decoder as BsonInput
         decoder.decodeMinKey()
         return BsonMinKey()
+    }
+
+}
+
+/**
+ * External serializer for [BsonSymbol].
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object BsonSymbolSerializer : KSerializer<BsonSymbol> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveDescriptor(BsonSymbol::class.qualifiedName!!, PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: BsonSymbol) {
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeSymbol(value.symbol)
+    }
+
+    override fun deserialize(decoder: Decoder): BsonSymbol {
+        decoder.verify(); decoder as BsonInput
+        return BsonSymbol(decoder.decodeSymbol())
     }
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/BsonPrimitiveSerializers.kt
@@ -21,9 +21,9 @@ import org.bson.BsonType.*
  * - [BsonInt64]
  * - [BsonDecimal128]
  * - [BsonRegularExpression]
- *
- * Note: Doesn't support deprecated or internal types:
  * - [BsonDbPointer]
+ *
+ * Note: Doesn't support some of deprecated or internal types:
  * - [BsonJavaScriptWithScope]
  * - [BsonMaxKey]
  * - [BsonMinKey]
@@ -60,6 +60,7 @@ object BsonPrimitiveSerializer : KSerializer<BsonValue> {
                     INT64 -> encoder.encode(BsonInt64Serializer, it.asInt64())
                     DECIMAL128 -> encoder.encode(BsonDecimal128Serializer, it.asDecimal128())
                     REGULAR_EXPRESSION -> encoder.encode(BsonRegularExpressionSerializer, it.asRegularExpression())
+                    DB_POINTER -> encoder.encode(BsonDbPointerSerializer, it.asDBPointer())
                     else -> throw RuntimeException("Should not reach here")
                 }
             }
@@ -340,4 +341,26 @@ object BsonNumberSerializer : KSerializer<BsonNumber> {
         decoder.verify(); decoder as BsonInput
         return decoder.decodeBson().asNumber()
     }
+}
+
+/**
+ * External serializer for [BsonDbPointer].
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object BsonDbPointerSerializer : KSerializer<BsonDbPointer> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveDescriptor(BsonDbPointer::class.qualifiedName!!, PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: BsonDbPointer) {
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeDbPointer(value)
+    }
+
+    override fun deserialize(decoder: Decoder): BsonDbPointer {
+        decoder.verify(); decoder as BsonInput
+        return decoder.decodeDbPointer()
+    }
+
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
@@ -5,6 +5,7 @@ import com.github.agcom.bson.serialization.encoders.BsonOutput
 import kotlinx.serialization.*
 import org.bson.BsonBinarySubType
 import org.bson.BsonMaxKey
+import org.bson.BsonMinKey
 import org.bson.UuidRepresentation
 import org.bson.internal.UuidHelper
 import org.bson.types.*
@@ -329,6 +330,31 @@ object MaxKeySerializer : KSerializer<MaxKey> {
         decoder.verify()
         decoder.decode(BsonMaxKeySerializer)
         return MaxKey()
+    }
+
+}
+
+/**
+ * [MinKey] serializer.
+ *
+ * Corresponds to [BsonMinKey][org.bson.BsonMinKey] type.
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object MinKeySerializer : KSerializer<MinKey> {
+
+    override val descriptor: SerialDescriptor
+        get() = BsonMinKeySerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: MinKey) {
+        encoder.verify()
+        encoder.encode(BsonMinKeySerializer, BsonMinKey())
+    }
+
+    override fun deserialize(decoder: Decoder): MinKey {
+        decoder.verify()
+        decoder.decode(BsonMinKeySerializer)
+        return MinKey()
     }
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
@@ -4,8 +4,6 @@ import com.github.agcom.bson.serialization.decoders.BsonInput
 import com.github.agcom.bson.serialization.encoders.BsonOutput
 import kotlinx.serialization.*
 import org.bson.BsonBinarySubType
-import org.bson.BsonMaxKey
-import org.bson.BsonMinKey
 import org.bson.UuidRepresentation
 import org.bson.internal.UuidHelper
 import org.bson.types.*
@@ -322,14 +320,13 @@ object MaxKeySerializer : KSerializer<MaxKey> {
         get() = BsonMaxKeySerializer.descriptor
 
     override fun serialize(encoder: Encoder, value: MaxKey) {
-        encoder.verify()
-        encoder.encode(BsonMaxKeySerializer, BsonMaxKey())
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeMaxKey(value)
     }
 
     override fun deserialize(decoder: Decoder): MaxKey {
-        decoder.verify()
-        decoder.decode(BsonMaxKeySerializer)
-        return MaxKey()
+        decoder.verify(); decoder as BsonInput
+        return decoder.decodeMaxKey()
     }
 
 }
@@ -347,14 +344,37 @@ object MinKeySerializer : KSerializer<MinKey> {
         get() = BsonMinKeySerializer.descriptor
 
     override fun serialize(encoder: Encoder, value: MinKey) {
-        encoder.verify()
-        encoder.encode(BsonMinKeySerializer, BsonMinKey())
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeMinKey(value)
     }
 
     override fun deserialize(decoder: Decoder): MinKey {
-        decoder.verify()
-        decoder.decode(BsonMinKeySerializer)
-        return MinKey()
+        decoder.verify(); decoder as BsonInput
+        return decoder.decodeMinKey()
+    }
+
+}
+
+/**
+ * Symbol string serializer.
+ *
+ * Corresponds to [BsonSymbol][org.bson.BsonSymbol] type.
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object SymbolSerializer : KSerializer<String> {
+
+    override val descriptor: SerialDescriptor
+        get() = BsonSymbolSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: String) {
+        encoder.verify(); encoder as BsonOutput
+        encoder.encodeSymbol(value);
+    }
+
+    override fun deserialize(decoder: Decoder): String {
+        decoder.verify(); decoder as BsonInput
+        return decoder.decodeSymbol()
     }
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/serializers/SpecialSerializers.kt
@@ -4,12 +4,10 @@ import com.github.agcom.bson.serialization.decoders.BsonInput
 import com.github.agcom.bson.serialization.encoders.BsonOutput
 import kotlinx.serialization.*
 import org.bson.BsonBinarySubType
+import org.bson.BsonMaxKey
 import org.bson.UuidRepresentation
 import org.bson.internal.UuidHelper
-import org.bson.types.Binary
-import org.bson.types.Code
-import org.bson.types.Decimal128
-import org.bson.types.ObjectId
+import org.bson.types.*
 import java.util.*
 import java.util.regex.Pattern
 
@@ -306,6 +304,31 @@ object DateSerializer : KSerializer<Date> {
     override fun deserialize(decoder: Decoder): Date {
         decoder.verify()
         return Date(decoder.decode(DateTimeSerializer))
+    }
+
+}
+
+/**
+ * [MaxKey] serializer.
+ *
+ * Corresponds to [BsonMaxKey][org.bson.BsonMaxKey] type.
+ *
+ * Can only be used with [Bson][com.github.agcom.bson.serialization.Bson] format.
+ */
+object MaxKeySerializer : KSerializer<MaxKey> {
+
+    override val descriptor: SerialDescriptor
+        get() = BsonMaxKeySerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: MaxKey) {
+        encoder.verify()
+        encoder.encode(BsonMaxKeySerializer, BsonMaxKey())
+    }
+
+    override fun deserialize(decoder: Decoder): MaxKey {
+        decoder.verify()
+        decoder.decode(BsonMaxKeySerializer)
+        return MaxKey()
     }
 
 }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -48,7 +48,7 @@ internal inline fun <R> BsonValue.fold(
     return when (bsonType) {
         ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although the user might meant a document.
         DOCUMENT -> document(asDocument())
-        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY, MIN_KEY ->
+        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY, MIN_KEY, SYMBOL ->
             primitive(this)
         else -> unexpected(this)
     }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -48,7 +48,7 @@ internal inline fun <R> BsonValue.fold(
     return when (bsonType) {
         ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although the user might meant a document.
         DOCUMENT -> document(asDocument())
-        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY, MIN_KEY, SYMBOL, UNDEFINED ->
+        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY, MIN_KEY, SYMBOL, UNDEFINED, TIMESTAMP ->
             primitive(this)
         else -> unexpected(this)
     }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -48,7 +48,7 @@ internal inline fun <R> BsonValue.fold(
     return when (bsonType) {
         ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although the user might meant a document.
         DOCUMENT -> document(asDocument())
-        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY, MIN_KEY, SYMBOL ->
+        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY, MIN_KEY, SYMBOL, UNDEFINED ->
             primitive(this)
         else -> unexpected(this)
     }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -48,7 +48,7 @@ internal inline fun <R> BsonValue.fold(
     return when (bsonType) {
         ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although the user might meant a document.
         DOCUMENT -> document(asDocument())
-        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY ->
+        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY, MIN_KEY ->
             primitive(this)
         else -> unexpected(this)
     }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -48,7 +48,7 @@ internal inline fun <R> BsonValue.fold(
     return when (bsonType) {
         ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although the user might meant a document.
         DOCUMENT -> document(asDocument())
-        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE ->
+        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE, MAX_KEY ->
             primitive(this)
         else -> unexpected(this)
     }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -48,7 +48,7 @@ internal inline fun <R> BsonValue.fold(
     return when (bsonType) {
         ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although the user might meant a document.
         DOCUMENT -> document(asDocument())
-        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL ->
+        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER ->
             primitive(this)
         else -> unexpected(this)
     }

--- a/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
+++ b/serialization/src/main/kotlin/com/github/agcom/bson/serialization/utils/BsonValue.kt
@@ -48,7 +48,7 @@ internal inline fun <R> BsonValue.fold(
     return when (bsonType) {
         ARRAY -> array(asArray()) // Array should be checked first as any array is a document but any document is not an array; Although the user might meant a document.
         DOCUMENT -> document(asDocument())
-        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER ->
+        DOUBLE, STRING, BINARY, OBJECT_ID, BOOLEAN, DATE_TIME, REGULAR_EXPRESSION, JAVASCRIPT, INT32, INT64, DECIMAL128, NULL, DB_POINTER, JAVASCRIPT_WITH_SCOPE ->
             primitive(this)
         else -> unexpected(this)
     }

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
@@ -771,6 +771,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     bson.context.getContextual(BsonDbPointer::class) shouldBe BsonDbPointerSerializer
                 }
 
+                "bson java script with scope" {
+                    bson.context.getContextual(BsonJavaScriptWithScope::class) shouldBe BsonJavaScriptWithScopeSerializer
+                }
+
             }
 
             "binary" {

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
@@ -767,6 +767,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     bson.context.getContextual(BsonString::class) shouldBe BsonStringSerializer
                 }
 
+                "bson db pointer" {
+                    bson.context.getContextual(BsonDbPointer::class) shouldBe BsonDbPointerSerializer
+                }
+
             }
 
             "binary" {

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
@@ -818,6 +818,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     bson.context.getContextual(BsonUndefined::class) shouldBe BsonUndefinedSerializer
                 }
 
+                "bson timestamp" {
+                    bson.context.getContextual(BsonTimestamp::class) shouldBe BsonTimestampSerializer
+                }
+
             }
 
             "binary" {

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
@@ -122,6 +122,11 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                         bson.toBson(MaxKeySerializer, maxKey) shouldBe BsonMaxKey()
                     }
 
+                    "min key" {
+                        val minKey = MinKey()
+                        bson.toBson(MinKeySerializer, minKey) shouldBe BsonMinKey()
+                    }
+
                 }
 
             }
@@ -317,6 +322,11 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     "max key" {
                         val maxKey = MaxKey()
                         bson.fromBson(MaxKeySerializer, BsonMaxKey()) shouldBe maxKey
+                    }
+
+                    "min key" {
+                        val minKey = MinKey()
+                        bson.fromBson(MinKeySerializer, BsonMinKey()) shouldBe minKey
                     }
 
                 }
@@ -786,6 +796,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     bson.context.getContextual(BsonMaxKey::class) shouldBe BsonMaxKeySerializer
                 }
 
+                "bson min key" {
+                    bson.context.getContextual(BsonMinKey::class) shouldBe BsonMinKeySerializer
+                }
+
             }
 
             "binary" {
@@ -866,6 +880,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
 
             "date" {
                 bson.context.getContextual(Date::class) shouldBe DateSerializer
+            }
+
+            "min key" {
+                bson.context.getContextual(MinKey::class) shouldBe MinKeySerializer
             }
 
         }

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
@@ -814,6 +814,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     bson.context.getContextual(BsonSymbol::class) shouldBe BsonSymbolSerializer
                 }
 
+                "bson undefined" {
+                    bson.context.getContextual(BsonUndefined::class) shouldBe BsonUndefinedSerializer
+                }
+
             }
 
             "binary" {

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
@@ -13,10 +13,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.serialization.builtins.*
 import org.bson.*
 import org.bson.io.BasicOutputBuffer
-import org.bson.types.Binary
-import org.bson.types.Code
-import org.bson.types.Decimal128
-import org.bson.types.ObjectId
+import org.bson.types.*
 import java.time.*
 import java.time.temporal.Temporal
 import java.time.temporal.TemporalAccessor
@@ -118,6 +115,11 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     "enum kind" {
                         val enum = HttpError.NOT_FOUND
                         bson.toBson(HttpError.serializer(), enum) shouldBe BsonString(enum.name)
+                    }
+
+                    "max key" {
+                        val maxKey = MaxKey()
+                        bson.toBson(MaxKeySerializer, maxKey) shouldBe BsonMaxKey()
                     }
 
                 }
@@ -310,6 +312,11 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     "enum kind" {
                         val enum = HttpError.NOT_FOUND
                         bson.fromBson(HttpError.serializer(), BsonString(enum.name)) shouldBe enum
+                    }
+
+                    "max key" {
+                        val maxKey = MaxKey()
+                        bson.fromBson(MaxKeySerializer, BsonMaxKey()) shouldBe maxKey
                     }
 
                 }
@@ -775,6 +782,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     bson.context.getContextual(BsonJavaScriptWithScope::class) shouldBe BsonJavaScriptWithScopeSerializer
                 }
 
+                "bson max key" {
+                    bson.context.getContextual(BsonMaxKey::class) shouldBe BsonMaxKeySerializer
+                }
+
             }
 
             "binary" {
@@ -795,6 +806,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
 
             "pattern" {
                 bson.context.getContextual(Pattern::class) shouldBe PatternSerializer
+            }
+
+            "max key" {
+                bson.context.getContextual(MaxKey::class) shouldBe MaxKeySerializer
             }
 
             "temporals" - {

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/BsonTest.kt
@@ -127,6 +127,11 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                         bson.toBson(MinKeySerializer, minKey) shouldBe BsonMinKey()
                     }
 
+                    "symbol" {
+                        val symbol = "hello"
+                        bson.toBson(SymbolSerializer, symbol) shouldBe BsonSymbol("hello")
+                    }
+
                 }
 
             }
@@ -327,6 +332,11 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
                     "min key" {
                         val minKey = MinKey()
                         bson.fromBson(MinKeySerializer, BsonMinKey()) shouldBe minKey
+                    }
+
+                    "symbol" {
+                        val symbol = "hello"
+                        bson.fromBson(SymbolSerializer, BsonSymbol("hello")) shouldBe symbol
                     }
 
                 }
@@ -798,6 +808,10 @@ class BsonTest : BsonInstanceTest by BsonInstanceTestDefault(), FreeSpec() {
 
                 "bson min key" {
                     bson.context.getContextual(BsonMinKey::class) shouldBe BsonMinKeySerializer
+                }
+
+                "bson symbol" {
+                    bson.context.getContextual(BsonSymbol::class) shouldBe BsonSymbolSerializer
                 }
 
             }

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
@@ -49,7 +49,8 @@ val testBsonValuePrimitives: List<BsonValue>
         BsonRegularExpression("hello"),
         BsonRegularExpression("hello", "cdgimstux"),
         BsonString("hello"),
-        BsonDbPointer("hello.world", ObjectId())
+        BsonDbPointer("hello.world", ObjectId()),
+        BsonJavaScriptWithScope("main() { console.log(hello) }", BsonDocument("hello", BsonString("bson")))
     )
 
 fun testBsonDocument(): BsonDocument = BsonDocument().also { doc ->

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
@@ -54,7 +54,8 @@ val testBsonValuePrimitives: List<BsonValue>
         BsonMaxKey(),
         BsonMinKey(),
         BsonSymbol("hello"),
-        BsonUndefined()
+        BsonUndefined(),
+        BsonTimestamp(100, 10)
     )
 
 fun testBsonDocument(): BsonDocument = BsonDocument().also { doc ->

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
@@ -53,7 +53,8 @@ val testBsonValuePrimitives: List<BsonValue>
         BsonJavaScriptWithScope("main() { console.log(hello) }", BsonDocument("hello", BsonString("bson"))),
         BsonMaxKey(),
         BsonMinKey(),
-        BsonSymbol("hello")
+        BsonSymbol("hello"),
+        BsonUndefined()
     )
 
 fun testBsonDocument(): BsonDocument = BsonDocument().also { doc ->

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
@@ -48,7 +48,8 @@ val testBsonValuePrimitives: List<BsonValue>
         BsonObjectId(ObjectId()),
         BsonRegularExpression("hello"),
         BsonRegularExpression("hello", "cdgimstux"),
-        BsonString("hello")
+        BsonString("hello"),
+        BsonDbPointer("hello.world", ObjectId())
     )
 
 fun testBsonDocument(): BsonDocument = BsonDocument().also { doc ->

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
@@ -50,7 +50,8 @@ val testBsonValuePrimitives: List<BsonValue>
         BsonRegularExpression("hello", "cdgimstux"),
         BsonString("hello"),
         BsonDbPointer("hello.world", ObjectId()),
-        BsonJavaScriptWithScope("main() { console.log(hello) }", BsonDocument("hello", BsonString("bson")))
+        BsonJavaScriptWithScope("main() { console.log(hello) }", BsonDocument("hello", BsonString("bson"))),
+        BsonMaxKey()
     )
 
 fun testBsonDocument(): BsonDocument = BsonDocument().also { doc ->

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
@@ -52,7 +52,8 @@ val testBsonValuePrimitives: List<BsonValue>
         BsonDbPointer("hello.world", ObjectId()),
         BsonJavaScriptWithScope("main() { console.log(hello) }", BsonDocument("hello", BsonString("bson"))),
         BsonMaxKey(),
-        BsonMinKey()
+        BsonMinKey(),
+        BsonSymbol("hello")
     )
 
 fun testBsonDocument(): BsonDocument = BsonDocument().also { doc ->

--- a/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
+++ b/serialization/src/test/kotlin/com/github/agcom/bson/serialization/models/TestModels.kt
@@ -51,7 +51,8 @@ val testBsonValuePrimitives: List<BsonValue>
         BsonString("hello"),
         BsonDbPointer("hello.world", ObjectId()),
         BsonJavaScriptWithScope("main() { console.log(hello) }", BsonDocument("hello", BsonString("bson"))),
-        BsonMaxKey()
+        BsonMaxKey(),
+        BsonMinKey()
     )
 
 fun testBsonDocument(): BsonDocument = BsonDocument().also { doc ->


### PR DESCRIPTION
Added support for the following types (which are deprecated or internal):
- `BsonDbPointer`
- `BsonJavaScriptWithScope`
- `BsonMaxKey`
- `BsonMinKey`
- `BsonSymbol`
- `BsonUndefined`
- `BsonTimestamp`

Closes #13.